### PR TITLE
Rewrite readme to use URL instead of relative path to the logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![logo](./docs/assets/logo.png)
+![logo](https://github.com/codellm-devkit/codeanalyzer-python/blob/main/docs/assets/logo.png?raw=true)
 
-Python Static Analysis Backend for CLDK
+# A Python Static Analysis Toolkit (and Library)
 
 A comprehensive static analysis tool for Python source code that provides symbol table generation, call graph analysis, and semantic analysis using Jedi, CodeQL, and Tree-sitter.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codeanalyzer-python"
-version = "0.1.2"
+version = "0.1.3"
 description = "Static Analysis on Python source code using Jedi, CodeQL and Treesitter."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -251,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "codeanalyzer-python"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "asteroid" },


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Fix logo rendering issue on PyPI by replacing relative image path with a raw GitHub URL in the README.

## Motivation and Context
PyPI does not support relative image paths in `README.md`. The logo (`./docs/assets/logo.png`) failed to render on the project page. This fix ensures the logo displays correctly by pointing to the raw image URL on GitHub.

## How Has This Been Tested?
- Verified rendering locally via a Markdown preview
- Uploaded the updated package to TestPyPI to confirm correct logo rendering

## Breaking Changes
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [Codellm-Devkit Documentation](https://codellm-devkit.info)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
This change improves visual presentation and polish of the package on PyPI. Using raw GitHub URLs is a standard workaround for PyPI’s lack of support for relative paths in long descriptions.
