### PR TITLE
Analysis venv (uv + Jedi wiring), external_symbols, app-scoped prune, --no-venv (#44 #45 #46 #47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ $ canpy --help
 │                                                               [default: lazy]                    │
 │ --skip-tests          --include-tests                         Skip test files in analysis.       │
 │                                                               [default: skip-tests]              │
+│ --no-venv             --venv                                  Skip virtualenv creation and       │
+│                                                               dependency installation; resolve   │
+│                                                               imports against the ambient Python │
+│                                                               environment instead.               │
+│                                                               [default: venv]                    │
 │ --file-name                              PATH                 Analyze only the specified file    │
 │                                                               (relative to input directory).     │
 │ --cache-dir       -c                     PATH                 Directory to store analysis cache. │

--- a/codeanalyzer/__main__.py
+++ b/codeanalyzer/__main__.py
@@ -104,6 +104,14 @@ def main(
             help="Skip test files in analysis.",
         ),
     ] = True,
+    no_venv: Annotated[
+        bool,
+        typer.Option(
+            "--no-venv/--venv",
+            help="Skip virtualenv creation and dependency installation; resolve "
+            "imports against the ambient Python environment instead.",
+        ),
+    ] = False,
     file_name: Annotated[
         Optional[Path],
         typer.Option(
@@ -144,6 +152,7 @@ def main(
         using_ray=using_ray,
         rebuild_analysis=rebuild_analysis,
         skip_tests=skip_tests,
+        no_venv=no_venv,
         file_name=file_name,
         cache_dir=cache_dir,
         clear_cache=clear_cache,

--- a/codeanalyzer/core.py
+++ b/codeanalyzer/core.py
@@ -66,6 +66,7 @@ class Codeanalyzer:
         self.skip_tests = options.skip_tests
         self.using_codeql = options.using_codeql
         self.rebuild_analysis = options.rebuild_analysis
+        self.no_venv = options.no_venv
         self.cache_dir = (
             options.cache_dir.resolve() if options.cache_dir is not None else self.project_dir
         ) / ".codeanalyzer"
@@ -260,8 +261,13 @@ class Codeanalyzer:
         venv_path = self.cache_dir / self.project_dir.name / "virtualenv"
         # Ensure the cache directory exists for this project
         venv_path.parent.mkdir(parents=True, exist_ok=True)
+        if self.no_venv:
+            logger.info(
+                "--no-venv: using the ambient Python environment "
+                "(skipping virtualenv creation and dependency installation)"
+            )
         # Create the virtual environment if it does not exist
-        if not venv_path.exists() or self.rebuild_analysis:
+        if not self.no_venv and (not venv_path.exists() or self.rebuild_analysis):
             logger.info(f"(Re-)creating virtual environment at {venv_path}")
             self._cmd_exec_helper(
                 [str(self._get_base_interpreter()), "-m", "venv", str(venv_path)],
@@ -320,8 +326,9 @@ class Codeanalyzer:
         # Point Jedi at the analysis venv so it resolves the project's third-party
         # imports. This runs on both a fresh build and a lazy reuse of an existing
         # venv -- previously self.virtualenv stayed None, so the install above was
-        # never actually used by the symbol-table builder.
-        if venv_path.exists():
+        # never actually used by the symbol-table builder. With --no-venv we leave
+        # it None so Jedi resolves against the ambient interpreter instead.
+        if not self.no_venv and venv_path.exists():
             self.virtualenv = venv_path
 
         if self.using_codeql:

--- a/codeanalyzer/core.py
+++ b/codeanalyzer/core.py
@@ -8,7 +8,13 @@ from typing import Any, Dict, Optional, Union, List
 
 import ray
 from codeanalyzer.utils import logger
-from codeanalyzer.schema import PyApplication, PyModule, model_dump_json, model_validate_json
+from codeanalyzer.schema import (
+    PyApplication,
+    PyExternalSymbol,
+    PyModule,
+    model_dump_json,
+    model_validate_json,
+)
 from codeanalyzer.schema.py_schema import PyCallEdge
 from codeanalyzer.semantic_analysis.call_graph import (
     jedi_call_graph_edges,
@@ -379,6 +385,43 @@ class Codeanalyzer:
             logger.info(f"Clearing cache directory: {self.cache_dir}")
             shutil.rmtree(self.cache_dir)
 
+    @staticmethod
+    def _compute_external_symbols(symbol_table, call_graph):
+        """Build the external-symbol map: every call-graph endpoint whose signature
+        is not a declared class/callable in the symbol table is an external (an
+        imported library or builtin member). ``name``/``module`` are derived from
+        the signature (best effort: split on the last dot)."""
+        declared = set()
+
+        def walk_callable(c):
+            declared.add(c.signature)
+            for ic in (c.inner_callables or {}).values():
+                walk_callable(ic)
+            for cl in (c.inner_classes or {}).values():
+                walk_class(cl)
+
+        def walk_class(cl):
+            declared.add(cl.signature)
+            for m in (cl.methods or {}).values():
+                walk_callable(m)
+            for ic in (cl.inner_classes or {}).values():
+                walk_class(ic)
+
+        for mod in symbol_table.values():
+            for c in (mod.functions or {}).values():
+                walk_callable(c)
+            for cl in (mod.classes or {}).values():
+                walk_class(cl)
+
+        externals: Dict[str, PyExternalSymbol] = {}
+        for edge in call_graph:
+            for sig in (edge.source, edge.target):
+                if sig in declared or sig in externals:
+                    continue
+                module, name = sig.rsplit(".", 1) if "." in sig else (sig, sig)
+                externals[sig] = PyExternalSymbol(name=name, module=module)
+        return externals
+
     def analyze(self) -> PyApplication:
         """Analyze the project and return a PyApplication with symbol table.
         
@@ -418,8 +461,19 @@ class Codeanalyzer:
         jedi_edges = jedi_call_graph_edges(symbol_table)
         call_graph = merge_edges(jedi_edges, codeql_edges)
 
+        # Classify call-graph endpoints that are not declared in the symbol table
+        # (imported library / builtin members) once, so the JSON and Neo4j backends
+        # share one authoritative external-symbol set.
+        external_symbols = self._compute_external_symbols(symbol_table, call_graph)
+
         # Recreate pyapplication
-        app = PyApplication.builder().symbol_table(symbol_table).call_graph(call_graph).build()
+        app = (
+            PyApplication.builder()
+            .symbol_table(symbol_table)
+            .call_graph(call_graph)
+            .external_symbols(external_symbols)
+            .build()
+        )
         
         # Save to cache
         self._save_analysis_cache(app, cache_file)

--- a/codeanalyzer/core.py
+++ b/codeanalyzer/core.py
@@ -226,6 +226,29 @@ class Codeanalyzer:
             f"a working Python interpreter that can create virtual environments."
         )
 
+    @staticmethod
+    def _uv_bin() -> Optional[str]:
+        """Path to a uv binary: the one bundled with the ``uv`` PyPI package (a
+        dependency, so normally always present -- including inside a Docker image),
+        else a uv on PATH, else ``None`` (callers fall back to pip)."""
+        try:
+            from uv import find_uv_bin
+
+            return str(find_uv_bin())
+        except Exception:
+            return shutil.which("uv")
+
+    def _install_into_venv(self, venv_python: Path, args: List[str]) -> None:
+        """Install packages into the target venv, preferring uv for speed (parallel
+        downloads + a shared global cache) and falling back to the venv's own pip
+        when uv is unavailable."""
+        uv = self._uv_bin()
+        if uv:
+            cmd = [uv, "pip", "install", "--python", str(venv_python), *args]
+        else:
+            cmd = [str(venv_python), "-m", "pip", "install", *args]
+        self._cmd_exec_helper(cmd, cwd=self.project_dir, check=True)
+
     def __enter__(self) -> "Codeanalyzer":
         # If no virtualenv is provided, try to create one using requirements.txt or pyproject.toml
         venv_path = self.cache_dir / self.project_dir.name / "virtualenv"
@@ -249,24 +272,19 @@ class Codeanalyzer:
                 ("test-requirements.txt", ["-r"]),
             ]
 
-            for dep_file, pip_args in dependency_files:
+            for dep_file, _ in dependency_files:
                 if (self.project_dir / dep_file).exists():
                     logger.info(f"Installing dependencies from {dep_file}")
-                    self._cmd_exec_helper(
-                        [str(venv_python), "-m", "pip", "install", "-U"] + pip_args + [str(self.project_dir / dep_file)],
-                        cwd=self.project_dir,
-                        check=True,
+                    self._install_into_venv(
+                        venv_python,
+                        ["--upgrade", "-r", str(self.project_dir / dep_file)],
                     )
 
             # Handle Pipenv files
             if (self.project_dir / "Pipfile").exists():
                 logger.info("Installing dependencies from Pipfile")
                 # Note: This would require pipenv to be installed
-                self._cmd_exec_helper(
-                    [str(venv_python), "-m", "pip", "install", "pipenv"],
-                    cwd=self.project_dir,
-                    check=True,
-                )
+                self._install_into_venv(venv_python, ["pipenv"])
                 self._cmd_exec_helper(
                     ["pipenv", "install", "--dev"],
                     cwd=self.project_dir,
@@ -289,13 +307,16 @@ class Codeanalyzer:
 
             if any((self.project_dir / file).exists() for file in package_definition_files):
                 logger.info("Installing project in editable mode")
-                self._cmd_exec_helper(
-                    [str(venv_python), "-m", "pip", "install", "-e", str(self.project_dir)],
-                    cwd=self.project_dir,
-                    check=True,
-                )
+                self._install_into_venv(venv_python, ["-e", str(self.project_dir)])
             else:
                 logger.warning("No package definition files found, skipping editable installation")
+
+        # Point Jedi at the analysis venv so it resolves the project's third-party
+        # imports. This runs on both a fresh build and a lazy reuse of an existing
+        # venv -- previously self.virtualenv stayed None, so the install above was
+        # never actually used by the symbol-table builder.
+        if venv_path.exists():
+            self.virtualenv = venv_path
 
         if self.using_codeql:
             logger.info(f"(Re-)initializing CodeQL analysis for {self.project_dir}")

--- a/codeanalyzer/neo4j/bolt.py
+++ b/codeanalyzer/neo4j/bolt.py
@@ -77,6 +77,13 @@ def bolt_writer(rows: GraphRows, cfg: BoltConfig, full_run: bool) -> None:
             for stmt in [*CONSTRAINTS, *INDEXES]:
                 s.run(stmt)
 
+        # The application anchor (a shared node) — used to scope the orphan prune
+        # so it never touches modules belonging to a different :PyApplication.
+        app_name = next(
+            (n.value for n in rows.nodes if n.labels and n.labels[0] == "PyApplication"),
+            None,
+        )
+
         # Partition nodes by owning module; shared nodes have no _module.
         by_module: Dict[str, List[NodeRow]] = {}
         shared: List[NodeRow] = []
@@ -135,13 +142,17 @@ def bolt_writer(rows: GraphRows, cfg: BoltConfig, full_run: bool) -> None:
         _upsert_edges(session, neo4j, edges)
 
         # 6. orphan prune — only safe on a full run (a targeted run can't tell deleted from untargeted).
-        if full_run:
+        # Scope to THIS application's anchor so a full run for application B never
+        # deletes application A's modules from a shared database.
+        if full_run and app_name is not None:
             present = list(by_module.keys())
             with session() as s:
                 res = s.run(
-                    "MATCH (m:PyModule) WHERE NOT m.file_key IN $present "
+                    "MATCH (:PyApplication {name: $app})-[:PY_HAS_MODULE]->(m:PyModule) "
+                    "WHERE NOT m.file_key IN $present "
                     f"OPTIONAL MATCH (m)-{DESCENDANTS}->(x) DETACH DELETE x, m "
                     "RETURN count(m) AS pruned",
+                    app=app_name,
                     present=present,
                 )
                 pruned = res.single()

--- a/codeanalyzer/neo4j/catalog.py
+++ b/codeanalyzer/neo4j/catalog.py
@@ -34,7 +34,7 @@ from typing import Dict, List
 
 from codeanalyzer.neo4j.schema import CONSTRAINTS, INDEXES
 
-SCHEMA_VERSION = "1.0.0"
+SCHEMA_VERSION = "1.1.0"
 
 # PropType ∈ {"string", "integer", "float", "boolean", "string[]", "integer[]"}.
 
@@ -119,7 +119,7 @@ NODE_LABELS: List[NodeLabel] = [
         "PyExternal",
         "PySymbol",
         "signature",
-        {"signature": "string", "name": "string"},
+        {"signature": "string", "name": "string", "module": "string"},
     ),
     NodeLabel("PyPackage", "PyPackage", "name", {"name": "string"}),
     NodeLabel(

--- a/codeanalyzer/neo4j/project.py
+++ b/codeanalyzer/neo4j/project.py
@@ -60,11 +60,12 @@ def project(app: PyApplication, app_name: str) -> GraphRows:
         b.edge("PY_HAS_MODULE", app_ref, mod_ref)
         _project_module_body(b, file_key, mod_ref, mod)
 
-    # The aggregated :PY_CALLS twin. Endpoints not present in the symbol table become
-    # :PyExternal ghost nodes (the analyzer already preserves them as ghost nodes).
+    # The aggregated :PY_CALLS twin. Endpoints listed in app.external_symbols become
+    # :PyExternal ghost nodes; the rest are declared :PySymbol nodes already emitted.
+    externals = app.external_symbols or {}
     for e in app.call_graph:
-        src = _call_endpoint(b, e.source)
-        tgt = _call_endpoint(b, e.target)
+        src = _call_endpoint(b, e.source, externals)
+        tgt = _call_endpoint(b, e.target, externals)
         b.edge("PY_CALLS", src, tgt, _call_edge_props(e.weight, list(e.provenance or [])))
 
     return b.finish()
@@ -74,13 +75,20 @@ def _sym(signature: str) -> NodeRef:
     return NodeRef("PySymbol", "signature", signature)
 
 
-def _call_endpoint(b: RowBuilder, signature: str) -> NodeRef:
-    """A call-graph endpoint: a known callable already emitted, or a phantom
-    :PyExternal symbol materialized on demand for a ghost target."""
-    if b.has_key(signature):
+def _call_endpoint(b: RowBuilder, signature: str, externals: dict) -> NodeRef:
+    """A call-graph endpoint: a declared callable already emitted, or an external
+    symbol (imported library / builtin member) materialized as a :PyExternal ghost.
+
+    Classification is authoritative -- it comes from ``app.external_symbols``, not a
+    "present in the graph" heuristic -- so an imported module name (which exists only
+    as a :PyPackage) can never shadow the call target. A small fallback still
+    materializes an external for any endpoint that is neither declared nor listed."""
+    ext = externals.get(signature)
+    if ext is None and b.has_key("PySymbol", signature):
         return _sym(signature)
-    name = signature.rsplit(".", 1)[-1] if "." in signature else signature
-    return b.node(["PySymbol", "PyExternal"], "signature", signature, {"name": name})
+    name = ext.name if ext is not None else (signature.rsplit(".", 1)[-1] if "." in signature else signature)
+    module = ext.module if ext is not None else None
+    return b.node(["PySymbol", "PyExternal"], "signature", signature, prune({"name": name, "module": module}))
 
 
 # ----------------------------------------------------------------------------------------------

--- a/codeanalyzer/neo4j/rows.py
+++ b/codeanalyzer/neo4j/rows.py
@@ -83,7 +83,11 @@ class RowBuilder:
         self._nodes: Dict[str, NodeRow] = {}  # key: f"{labels[0]} {value}"
         self._edges: List[EdgeRow] = []
         self._deferred: List[EdgeRow] = []  # edges gated against node existence at finish()
-        self._keys: set = set()  # every node value seen, for resolved-gating
+        # (merge_label, value) of every node seen, for resolved-gating. Keyed by
+        # label too so a :PyPackage name can't shadow a :PySymbol signature (and
+        # vice versa) — otherwise a call to an imported module name like ``os``
+        # resolves to a :PySymbol node that was never created and the edge is lost.
+        self._keys: set = set()
 
     def node(self, labels: List[str], key_prop: str, value: str, props: Props) -> NodeRef:
         """Upsert a node. Re-seeing the same ``(labels[0], value)`` merges props
@@ -98,7 +102,7 @@ class RowBuilder:
                     existing.labels.append(label)
         else:
             self._nodes[node_id] = NodeRow(list(labels), key_prop, value, dict(props))
-        self._keys.add(value)
+        self._keys.add((labels[0], value))
         return NodeRef(labels[0], key_prop, value)
 
     def edge(self, type_: str, from_ref: NodeRef, to_ref: NodeRef, props: Optional[Props] = None) -> None:
@@ -121,12 +125,13 @@ class RowBuilder:
             )
         )
 
-    def has_key(self, value: str) -> bool:
-        return value in self._keys
+    def has_key(self, label: str, value: str) -> bool:
+        """Whether a node with this ``(merge_label, value)`` identity was emitted."""
+        return (label, value) in self._keys
 
     def finish(self) -> GraphRows:
         for e in self._deferred:
-            if e.to_ref.value in self._keys:
+            if (e.to_ref.label, e.to_ref.value) in self._keys:
                 self._edges.append(e)
         nodes = sorted(self._nodes.values(), key=lambda n: f"{n.labels[0]} {n.value}")
         edges = sorted(self._edges, key=lambda e: f"{e.type} {e.from_ref.value} {e.to_ref.value}")

--- a/codeanalyzer/options/options.py
+++ b/codeanalyzer/options/options.py
@@ -38,6 +38,7 @@ class AnalysisOptions:
     using_ray: bool = False
     rebuild_analysis: bool = False
     skip_tests: bool = True
+    no_venv: bool = False
     file_name: Optional[Path] = None
     cache_dir: Optional[Path] = None
     clear_cache: bool = False

--- a/codeanalyzer/schema/__init__.py
+++ b/codeanalyzer/schema/__init__.py
@@ -8,6 +8,7 @@ from .py_schema import (
     PyClass,
     PyClassAttribute,
     PyComment,
+    PyExternalSymbol,
     PyImport,
     PyModule,
     PyVariableDeclaration,
@@ -15,6 +16,7 @@ from .py_schema import (
 
 __all__ = [
     "PyApplication",
+    "PyExternalSymbol",
     "PyImport",
     "PyComment",
     "PyModule",

--- a/codeanalyzer/schema/py_schema.py
+++ b/codeanalyzer/schema/py_schema.py
@@ -360,8 +360,23 @@ class PyCallEdge(BaseModel):
 
 @builder
 @msgpk
+class PyExternalSymbol(BaseModel):
+    """A call-graph target outside the analyzed project -- an imported library or
+    builtin member. Mirrors codeanalyzer-typescript's ``TSExternalSymbol`` and is
+    keyed in ``PyApplication.external_symbols`` by its call-graph signature."""
+
+    name: str  # the member/short name, e.g. "get" for "requests.get"
+    module: Optional[str] = None  # best-effort owning module, e.g. "requests"
+
+
+@builder
+@msgpk
 class PyApplication(BaseModel):
     """Represents a Python application."""
 
     symbol_table: Dict[str, PyModule]
     call_graph: List[PyCallEdge] = []
+    # Call-graph endpoints not declared in the symbol table (imported library /
+    # builtin members), keyed by signature. Populated by the analyzer so every
+    # backend (JSON and Neo4j) shares one authoritative external-symbol set.
+    external_symbols: Dict[str, PyExternalSymbol] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ dependencies = [
     "ray==2.0.0; python_version < '3.11'",
     "ray>=2.10.0,<3.0.0; python_version >= '3.11'",
     "packaging>=25.0",
+    # uv -- installs the analyzed project's deps into the analysis venv quickly.
+    # Shipped as a self-contained binary in its wheel, so it's available wherever
+    # canpy is pip-installed (incl. Docker); core.py falls back to pip without it.
+    "uv>=0.5.0",
 ]
 
 [project.optional-dependencies]

--- a/schema.neo4j.json
+++ b/schema.neo4j.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "generator": "codeanalyzer-python",
   "marker_labels": [],
   "node_labels": [
@@ -67,7 +67,8 @@
       "key": "signature",
       "properties": {
         "signature": "string",
-        "name": "string"
+        "name": "string",
+        "module": "string"
       }
     },
     {

--- a/test/sample_graph_app.py
+++ b/test/sample_graph_app.py
@@ -14,6 +14,7 @@ from codeanalyzer.schema import (
     PyClass,
     PyClassAttribute,
     PyComment,
+    PyExternalSymbol,
     PyImport,
     PyModule,
     PyVariableDeclaration,
@@ -149,4 +150,7 @@ def make_sample_app() -> PyApplication:
     return PyApplication(
         symbol_table={"src/service.py": service_mod, "src/util.py": util_mod},
         call_graph=call_graph,
+        # The ghost edge's target (requests.get) is a library member, recorded as a
+        # first-class external symbol so the projection emits a :PyExternal for it.
+        external_symbols={"requests.get": PyExternalSymbol(name="get", module="requests")},
     )

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -38,6 +38,27 @@ def test_cli_call_symbol_table_with_json(cli_runner, whole_applications__xarray)
     assert len(json_obj["symbol_table"]) > 0, "Symbol table should not be empty"
 
 
+def test_no_venv_skips_virtualenv(
+    cli_runner, single_functionalities__stuff_nested_in_functions, tmp_path
+):
+    """#46: --no-venv must skip virtualenv creation/installation and still analyze."""
+    out = tmp_path / "out"
+    cache = tmp_path / "cache"
+    result = cli_runner.invoke(
+        app,
+        [
+            "--input", str(single_functionalities__stuff_nested_in_functions),
+            "--output", str(out),
+            "--cache-dir", str(cache),
+            "--no-venv", "--no-codeql", "--no-ray",
+        ],
+        env={"NO_COLOR": "1", "TERM": "dumb"},
+    )
+    assert result.exit_code == 0, result.output
+    assert (out / "analysis.json").exists(), "analysis.json should still be produced with --no-venv"
+    assert not list(cache.rglob("virtualenv")), "--no-venv must not create a virtualenv"
+
+
 def test_single_file(cli_runner, single_functionalities__stuff_nested_in_functions):
     """Must be able to run the CLI with single file analysis using --file-name flag."""
     output_dir = single_functionalities__stuff_nested_in_functions.joinpath(".output")

--- a/test/test_neo4j_bolt.py
+++ b/test/test_neo4j_bolt.py
@@ -15,8 +15,23 @@ import pytest
 
 from codeanalyzer.neo4j import project
 from codeanalyzer.neo4j.bolt import BoltConfig, bolt_writer
+from codeanalyzer.schema import PyApplication, PyCallable, PyModule
 
 from sample_graph_app import make_sample_app
+
+
+def _single_module_app(file_key: str = "appb/main.py") -> PyApplication:
+    """A minimal second application with its own (distinct) module file_key."""
+    fn = PyCallable(
+        name="main", path=file_key, signature="appb.main", return_type="None",
+        code="def main():\n    ...", start_line=1, end_line=2,
+        code_start_line=1, cyclomatic_complexity=1,
+    )
+    mod = PyModule(
+        file_path=file_key, module_name="appb.main", functions={"main": fn},
+        content_hash="h-b", last_modified=1.0, file_size=10,
+    )
+    return PyApplication(symbol_table={file_key: mod}, call_graph=[])
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("RUN_CONTAINER_TESTS"),
@@ -103,6 +118,21 @@ def test_full_push_materializes_the_whole_graph_and_schema(driver, cfg):
     )
     # The ghost edge resolved to an :PyExternal node.
     assert _num(driver, "MATCH (e:PyExternal) RETURN count(e)") >= 1
+
+
+def test_full_run_does_not_prune_another_applications_modules(driver, cfg):
+    """Regression for #45: a full-run push for one application must not prune the
+    modules of a *different* application sharing the database."""
+    bolt_writer(project(make_sample_app(), "app-a"), cfg, full_run=True)
+    before = _num(driver, "MATCH (:PyApplication {name:'app-a'})-[:PY_HAS_MODULE]->(m) RETURN count(m)")
+    assert before > 0
+
+    # A full-run push for a different application must leave app-a untouched.
+    bolt_writer(project(_single_module_app(), "app-b"), cfg, full_run=True)
+
+    after = _num(driver, "MATCH (:PyApplication {name:'app-a'})-[:PY_HAS_MODULE]->(m) RETURN count(m)")
+    assert after == before, "full-run push for app-b pruned app-a's modules (#45)"
+    assert _num(driver, "MATCH (:PyApplication {name:'app-b'})-[:PY_HAS_MODULE]->(m) RETURN count(m)") == 1
 
 
 def test_re_pushing_identical_analysis_is_idempotent(driver, cfg):

--- a/test/test_neo4j_schema.py
+++ b/test/test_neo4j_schema.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from codeanalyzer.neo4j import NODE_LABELS, REL_TYPES, build_schema_document, project
 from codeanalyzer.neo4j.catalog import MARKER_LABELS
 from codeanalyzer.neo4j.cypher import render_cypher
+from codeanalyzer.schema import PyApplication, PyCallable, PyImport, PyModule
+from codeanalyzer.schema.py_schema import PyCallEdge
 
 from sample_graph_app import make_sample_app
 
@@ -85,6 +87,38 @@ def test_render_cypher_is_deterministic_and_self_contained():
     assert "CREATE CONSTRAINT" in a
     assert "DETACH DELETE" in a
     assert "MERGE (n:PySymbol {signature: row.k})" in a
+
+
+def test_call_edge_to_imported_module_name_is_not_dropped():
+    """Regression for #44: a call whose target is a bare module name that is also
+    imported (e.g. ``os``) must not be dropped. The import creates a :PyPackage
+    named ``os``; that must not shadow the call target's :PySymbol signature."""
+    caller = PyCallable(
+        name="caller", path="m.py", signature="m.caller", return_type="None",
+        code="def caller():\n    os.getcwd()", start_line=1, end_line=2,
+        code_start_line=1, cyclomatic_complexity=1,
+    )
+    mod = PyModule(
+        file_path="m.py", module_name="m",
+        imports=[PyImport(module="os", name="getcwd")],
+        functions={"caller": caller},
+        content_hash="h", last_modified=1.0, file_size=10,
+    )
+    app = PyApplication(
+        symbol_table={"m.py": mod},
+        call_graph=[PyCallEdge(source="m.caller", target="os", weight=1, provenance=["jedi"])],
+    )
+    rows = project(app, "app")
+
+    calls_to_os = [e for e in rows.edges if e.type == "PY_CALLS" and e.to_ref.value == "os"]
+    assert len(calls_to_os) == 1, "PY_CALLS edge to imported module name 'os' was dropped"
+
+    # 'os' is materialized as a :PyExternal symbol (the call target) ...
+    assert any(n.value == "os" and "PyExternal" in n.labels for n in rows.nodes), \
+        ":PyExternal ghost for the call target 'os' is missing"
+    # ... distinct from the :PyPackage 'os' created by the import.
+    assert any(n.value == "os" and "PyPackage" in n.labels for n in rows.nodes), \
+        ":PyPackage for the import 'os' is missing"
 
 
 def test_checked_in_schema_matches_catalog():


### PR DESCRIPTION
## Summary

Fixes four issues on the Neo4j / analysis pipeline.

## Changes

### #47 -- install the analysis venv with uv and wire it to Jedi

The per-project analysis venv was built and populated but never used: `__init__`
left `self.virtualenv = None` and never reassigned it, so `SymbolTableBuilder` got
`None` and Jedi resolved against the default environment, ignoring the installed
dependencies. Now `self.virtualenv` is set on both a fresh build and a lazy reuse.
Dependency installation uses `uv` (`uv pip install --python <venv>`) instead of `pip`
for speed (parallel + shared cache); uv ships in its wheel so it is present
wherever canpy is installed, including Docker, with a pip fallback.

### #44 -- first-class external_symbols (codeanalyzer-typescript parity)

External call targets are now first-class in the IR instead of being re-derived
ad hoc in the projection. Adds PyExternalSymbol{name, module} and
PyApplication.external_symbols (mirrors TSExternalSymbol). The analyzer
classifies every call-graph endpoint not declared in the symbol table as an
external. The Neo4j projection emits :PyExternal authoritatively from that set,
so an imported module name (a :PyPackage) can no longer shadow a call target and
silently drop the PY_CALLS edge. :PyExternal gains a module property
(SCHEMA_VERSION 1.0.0 -> 1.1.0, additive). Node identity is also keyed by
(merge_label, value) so deferred PY_EXTENDS / PY_RESOLVES_TO edges cannot be
shadowed. Fixes the ~3.7% of call edges (targets like os/re/json) that were
dropped from the emitted graph.

### #45 -- scope the bolt full-run prune to the application anchor

The full-run orphan prune deleted any :PyModule not in the current emit across
the entire database, so a push for application B wiped application A's modules.
The prune is now anchored:

~~~cypher
MATCH (:PyApplication {name: $app})-[:PY_HAS_MODULE]->(m:PyModule)
WHERE NOT m.file_key IN $present
OPTIONAL MATCH (m)-[...]->(x)
DETACH DELETE x, m
~~~

so it only removes that application's vanished modules. A single Neo4j database
can now hold multiple applications via full-run --emit neo4j.

### #46 -- add --no-venv

New --no-venv/--venv flag (AnalysisOptions.no_venv). When set, skip venv
creation and dependency installation and resolve imports against the ambient
interpreter (self.virtualenv stays None). Useful in CI / containers where the
deps are already installed, for sandboxed runs without network, and for speed.

## Testing

- Schema conformance + a #44 regression test (call to an imported module name is
  preserved as a :PyExternal) -- pass.
- Bolt container tests via Testcontainers/podman, including a #45 regression
  (a full-run push for app-b leaves app-a intact) -- 4 pass against real Neo4j.
- A #46 CLI regression (no virtualenv created, analysis.json still produced) --
  pass.
- End-to-end: analyzing "import os; os.getcwd()" yields
  external_symbols: {os: {name: os, module: os}} and the projection preserves the
  PY_CALLS edge to a :PyExternal {module: os}.
- schema.neo4j.json regenerated (1.1.0).

## Closes

Closes #44
Closes #45
Closes #46
Closes #47
