### PR TITLE
ci(release): auto-open a python-sdk incorporation issue on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,3 +181,47 @@ jobs:
           git add Formula/codeanalyzer-python.rb
           git commit -m "codeanalyzer-python ${VERSION}" || { echo "no formula change"; exit 0; }
           git push
+
+  # Open a tracking issue on the python-sdk (CLDK) consumer so its
+  # codeanalyzer-python pin and integration can be brought up to this release.
+  # The issue body is the CHANGELOG section for this version. Split into its own
+  # job (needs: release) so a failure here -- e.g. a missing SDK_ISSUE_TOKEN --
+  # is isolated from the PyPI and GitHub Release steps above. Issues are
+  # repository-scoped (not branch-scoped), so this opens one on python-sdk.
+  notify-python-sdk:
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      # Pull the lines under "## [VERSION]" up to the next "## [" heading.
+      - name: Extract changelog section for this release
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          {
+            echo "A new \`codeanalyzer-python\` release (\`v${VERSION}\`) is published."
+            echo "Update the \`codeanalyzer-python\` pin in this repo and adapt the"
+            echo "integration to the changes below (see \`PyCodeanalyzer._run_analyzer\`)."
+            echo
+            awk -v ver="$VERSION" '
+              $0 ~ ("^## \\[" ver "\\]") { f = 1; print; next }
+              f && /^## \[/ { exit }
+              f { print }
+            ' CHANGELOG.md
+          } > "$RUNNER_TEMP/sdk_issue.md"
+          echo "----- issue body -----"; cat "$RUNNER_TEMP/sdk_issue.md"
+
+      - name: Create incorporation issue in python-sdk
+        env:
+          # PAT (or fine-grained token) with Issues:write on codellm-devkit/python-sdk.
+          # The default GITHUB_TOKEN is scoped to this repo only and cannot open
+          # issues cross-repo, mirroring HOMEBREW_TAP_TOKEN above.
+          GH_TOKEN: ${{ secrets.SDK_ISSUE_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          gh issue create \
+            --repo codellm-devkit/python-sdk \
+            --title "Incorporate codeanalyzer-python v${VERSION}" \
+            --body-file "$RUNNER_TEMP/sdk_issue.md"


### PR DESCRIPTION
Adds a release-workflow job that opens a tracking issue on python-sdk whenever a new version ships, so the consumer's pin and integration get updated.

## Motivation and Context

python-sdk consumes codeanalyzer-python as a library and pins it exactly. A release (especially a breaking one like 0.3.0) needs a matching change there. This makes that follow-up automatic instead of manual.

## How Has This Been Tested?

YAML validated. The CHANGELOG extraction (awk pulls the section under `## [VERSION]` up to the next `## [`) was run against the current file and returns the full 0.3.0 section. The cross-repo issue creation cannot run until the token secret exists (see Breaking Changes).

## Breaking Changes

None to the package. One setup step: add a repo secret `SDK_ISSUE_TOKEN`, a PAT (or fine-grained token) with Issues:write on codellm-devkit/python-sdk. Without it, the new job fails, but it is isolated (needs: release), so PyPI and the GitHub Release still succeed. Mirrors the existing `HOMEBREW_TAP_TOKEN` pattern.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have read the [Codellm-Devkit Documentation](https://codellm-devkit.info)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

New job `notify-python-sdk`:

```
needs: release
extract:  awk the "## [VERSION]" CHANGELOG block into a body file
create:   gh issue create --repo codellm-devkit/python-sdk
          --title "Incorporate codeanalyzer-python v<version>"
          --body-file <changelog section>
```

Note: GitHub issues are repository-scoped, not branch-scoped, so the issue opens on the python-sdk repo (it cannot target a specific branch).
