### PR TITLE
ci: release-announcer agent (rewrites the announcement Discussion)

### DIFF
--- a/.github/release-announcer/CLAUDE.md
+++ b/.github/release-announcer/CLAUDE.md
@@ -1,0 +1,73 @@
+# Release announcer
+
+You are maintaining the release-announcement Discussion for a codellm-devkit
+analyzer repo (codeanalyzer-python, codeanalyzer-java, codeanalyzer-typescript).
+
+On each release, a workflow auto-posts a Discussion seeded with the raw CHANGELOG
+block and the GitHub release notes. That seed is developer-facing. Your job is to
+rewrite it into a clear, user-facing announcement so a reader understands what
+ACTUALLY changed and why it matters, then update the Discussion in place.
+
+## When you run
+
+You run when a new release is published (the `release: published` event, or a
+manual dispatch that passes the tag). The tag is the release to announce, for
+example `v0.3.0`. The repo is the one you are running in.
+
+## Steps
+
+1. Read the release.
+   `gh release view <tag> --repo <owner>/<repo> --json tagName,name,publishedAt,body`
+   Note the version and the auto-generated "What's Changed" PR list.
+
+2. Read the CHANGELOG section for this version: the block under `## [<version>]`
+   in CHANGELOG.md. If the repo has no CHANGELOG.md (codeanalyzer-java does not),
+   use the release body alone.
+
+3. Find the announcement Discussion. It is in the "Announcements" category,
+   titled `New Release 📯 <name> <version>`, and exists in BOTH the repo and the
+   org (codellm-devkit/.github). Read the current body (the raw seed).
+
+4. For any change you cannot fully explain, read the referenced PR
+   (`gh pr view <n> --repo <owner>/<repo>`). Never guess what a change does.
+
+5. Compose a better announcement:
+   - Open with one or two plain sentences: what this release is and who should care.
+   - "What's new": each feature with a sentence on the user impact, not just its title.
+   - "Breaking changes": what breaks and the exact upgrade step. Omit if none.
+   - "Fixes": short bullets.
+   - "Install": keep the install commands from the release notes.
+   - End with a link to the full release notes.
+   - Keep the raw CHANGELOG and release notes at the bottom inside a collapsed
+     `<details>` block so nothing is lost.
+
+6. Update BOTH Discussions (repo and org) with the new body. Keep the title
+   `New Release 📯 <name> <version>`.
+
+## Commands
+
+Resolve the Discussion node ID (repeat for repo and for the `.github` org repo):
+
+```
+gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){discussion(number:$n){id}}}' -f o=codellm-devkit -f r=<repo> -F n=<number>
+```
+
+Update it:
+
+```
+gh api graphql -f query='mutation($id:ID!,$t:String!,$b:String!){updateDiscussion(input:{discussionId:$id,title:$t,body:$b}){discussion{url}}}' -f id=<id> -f t='<title>' -f b="$(cat body.md)"
+```
+
+The org-level Discussion lives in `codellm-devkit/.github`. Authenticate `gh`
+with a token that has repo + discussions scope (the workflow passes
+`CLDK_AUTH_TOKEN` as `GH_TOKEN`).
+
+## Rules
+
+- Accuracy first. Only state changes that appear in the CHANGELOG, the release
+  notes, or the PRs. If you cannot verify a claim, drop it. Do not invent.
+- Write for users, not maintainers: explain impact and the why, not just the what.
+- No AI or assistant attribution anywhere: no "Generated with", no co-author
+  trailer, no robot emoji.
+- No emdashes. Use commas, colons, or parentheses.
+- Keep code fences around commands and install lines.

--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -1,0 +1,54 @@
+name: Announce release (agent)
+
+# When a release is published (the same v*.*.* tag the Python uv Release workflow
+# cuts), run a Claude Code agent that reads the auto-posted announcement Discussion
+# and rewrites it into a clear, user-facing message. The agent follows the playbook
+# in .github/release-announcer/CLAUDE.md.
+#
+# Requires two secrets:
+#   ANTHROPIC_API_KEY  - for the Claude Code action.
+#   CLDK_AUTH_TOKEN    - PAT with repo + discussions scope (also used by the release
+#                        workflow), so the agent can edit the repo and org Discussions.
+#
+# Runs after the release workflow has already published the release and seeded the
+# Discussion, so this only needs to improve an existing post.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to (re)announce, e.g. v0.3.0"
+        required: true
+
+permissions:
+  contents: read
+  discussions: write
+
+concurrency:
+  group: announce-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Rewrite the release announcement
+        uses: anthropics/claude-code-action@v1
+        env:
+          # gh (used by the agent) authenticates from GH_TOKEN; CLDK_AUTH_TOKEN can
+          # write Discussions in this repo and in codellm-devkit/.github.
+          GH_TOKEN: ${{ secrets.CLDK_AUTH_TOKEN }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            A new release was just published: ${{ github.event.release.tag_name || inputs.tag }}
+            for the ${{ github.repository }} repository.
+
+            Read .github/release-announcer/CLAUDE.md and follow it exactly to rewrite
+            the announcement Discussion (both the repo and the codellm-devkit/.github
+            org Discussion) for this release into a clear, user-facing message.


### PR DESCRIPTION
Adds a Claude Code agent that, on each release, turns the auto-posted announcement Discussion (raw CHANGELOG + release notes) into a clear, user-facing message explaining what actually changed.

## Motivation and Context
The release workflow seeds a Discussion with developer-facing CHANGELOG and release notes. This agent rewrites that into something users can read, grouped into what is new, breaking changes with upgrade steps, and fixes, while keeping the raw notes in a collapsed details block.

## How Has This Been Tested?
Workflow YAML validated. The playbook was applied by hand to the v0.3.0 Discussions (repo #57, org #5) to confirm the shape. The automated trigger has not run yet (needs the secret below).

## Breaking Changes
None. New files only.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ] I have read the [Codellm-Devkit Documentation](https://codellm-devkit.info)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Files:
- `.github/release-announcer/CLAUDE.md` the agent playbook (steps, commands, accuracy + no-attribution rules). Force-added since CLAUDE.md is in a global gitignore.
- `.github/workflows/announce-release.yml` triggers on release: published (and manual dispatch with a tag).

Requires two secrets:
- ANTHROPIC_API_KEY for the Claude Code action.
- CLDK_AUTH_TOKEN (already present) passed as GH_TOKEN so the agent can edit the repo and org Discussions.

Note: confirm the anthropics/claude-code-action@v1 input names against the version you pin before relying on it; the playbook itself is action-agnostic and also works from a manual or scheduled agent run.