### PR TITLE
chore: track repo CLAUDE.md with release-announcement cleanup playbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ uv.lock
 # Node / Astro docs-site build artifacts (never commit these)
 node_modules/
 .astro/
+
+# Track this repo's CLAUDE.md even though a global gitignore excludes CLAUDE.md
+!CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+Agent guidance for `codellm-devkit/codeanalyzer-python`.
+
+Respect the global `~/.claude/CLAUDE.md` instructions strictly.
+
+## Tidy up the release announcement
+
+Every `vX.Y.Z` tag makes the release workflow (`.github/workflows/release.yml`) auto-post an
+announcement to the **Announcements** discussion (this repo, and the org mirror in
+`codellm-devkit/.github`). That body is machine-generated from PR titles — it mis-categorizes
+changes, includes `chore(release)` noise, and buries breaking changes.
+
+When you're working in this repo, check whether the latest release's announcement still needs
+cleanup, and if so, fix it:
+
+1. **Find it.** `gh release view --json tagName,publishedAt`; then list recent discussions via
+   `gh api graphql` (repository → discussions), match category `Announcements` whose title carries
+   this release's version (the auto-post titles it `vX.Y.Z`; a cleaned-up one is
+   `📣 New Release: codeanalyzer-python X.Y.Z`). Keep the discussion node `id` and read its `body`.
+2. **Skip if already done.** If the body starts with `<!-- cleaned-up -->` (or already reads as a
+   clear, human-written announcement), do nothing.
+3. **Otherwise rewrite it** into a clear, user-facing announcement, grounded in `CHANGELOG.md` and
+   the referenced PRs/diff (not the auto-grouping — verify each change; never invent anything):
+   - **breaking changes first**, each with a one-line migration step;
+   - plain-language highlights (what it does, not the PR title);
+   - upgrade line: `pip install -U "codeanalyzer-python==X.Y.Z"`;
+   - links to the GitHub release and `CHANGELOG.md`.
+4. **Update in place.** Edit the discussion with the GraphQL `updateDiscussion` mutation (don't
+   open a new one): set the title to `📣 New Release: codeanalyzer-python X.Y.Z`, prepend
+   `<!-- cleaned-up -->` to the body, and mirror the same title and body to the org discussion.
+   This task only reads code and edits Discussions — it makes no commits.


### PR DESCRIPTION
Tracks this repo CLAUDE.md (a global gitignore was excluding it) and adds agent guidance to tidy up the auto-posted release announcement Discussion.

## Motivation and Context
The release workflow auto-posts a machine-generated announcement (PR-title grouping, chore noise, buried breaking changes). This playbook tells an agent working in the repo to rewrite it into a clear, user-facing post, in place, and mirror to the org. Mirrors the python-sdk playbook.

## How Has This Been Tested?
No code change. The flow was exercised by hand on the v0.3.0 discussions.

## Breaking Changes
None. Adds CLAUDE.md and one .gitignore negation (!CLAUDE.md).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [ ] I have read the [Codellm-Devkit Documentation](https://codellm-devkit.info)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Cleaned-up announcements are titled `📣 New Release: codeanalyzer-python X.Y.Z` and marked with a `<!-- cleaned-up -->` body comment so the agent skips already-done posts. The playbook reads code and edits Discussions only; it makes no commits.