### PR TITLE
feat: add canpy --version flag

### DIFF
--- a/codeanalyzer/__main__.py
+++ b/codeanalyzer/__main__.py
@@ -1,3 +1,4 @@
+from importlib.metadata import version as _pkg_version, PackageNotFoundError
 from pathlib import Path
 from typing import Optional, Annotated
 
@@ -10,7 +11,32 @@ from codeanalyzer.schema import model_dump_json
 from codeanalyzer.options import AnalysisOptions, EmitTarget, ShardStrategy
 
 
+def _version_callback(value: bool) -> None:
+    """Print the installed ``codeanalyzer-python`` version and exit.
+
+    Eager so it fires before the rest of the CLI callback (no -i/--input
+    required). Reads the version from package metadata so it always reflects
+    what is actually installed rather than a hardcoded string."""
+    if not value:
+        return
+    try:
+        installed = _pkg_version("codeanalyzer-python")
+    except PackageNotFoundError:
+        installed = "unknown"
+    typer.echo(f"canpy {installed}")
+    raise typer.Exit()
+
+
 def main(
+    version: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--version",
+            help="Show the canpy version and exit.",
+            callback=_version_callback,
+            is_eager=True,
+        ),
+    ] = None,
     input: Annotated[
         Optional[Path],
         typer.Option(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,4 +1,5 @@
 import json
+from importlib.metadata import version
 from pathlib import Path
 from codeanalyzer.__main__ import app
 from codeanalyzer.utils import logger
@@ -8,6 +9,14 @@ def test_cli_help(cli_runner):
     """Must be able to run the CLI and see help output."""
     result = cli_runner.invoke(app, ["--help"], env={"NO_COLOR": "1", "TERM": "dumb"})
     assert result.exit_code == 0
+
+
+def test_cli_version(cli_runner):
+    """`canpy --version` prints the installed version and exits 0 without -i/--input."""
+    result = cli_runner.invoke(app, ["--version"], env={"NO_COLOR": "1", "TERM": "dumb"})
+    assert result.exit_code == 0, result.output
+    assert version("codeanalyzer-python") in result.output
+    assert "canpy" in result.output
 
 def test_cli_call_symbol_table_with_json(cli_runner, whole_applications__xarray):
     """Must be able to run the CLI with symbol table analysis."""


### PR DESCRIPTION
## Summary

Adds a top-level `--version` option to the `canpy` CLI:

```console
$ canpy --version
canpy 0.3.0
```

## Details

- Implemented as an **eager Typer callback**, so it prints and exits before the rest of the CLI callback runs — `-i/--input` is **not** required.
- The version string is read from **installed package metadata** (`importlib.metadata.version("codeanalyzer-python")`) rather than hardcoded, so it always reflects what's actually installed. Falls back to `unknown` if metadata is unavailable. This matches the existing pattern in `codeanalyzer.schema`.
- Appears in `canpy --help`.

## Test

- New `test_cli_version` asserts exit code 0 and that the installed version + `canpy` appear in the output, with no `-i/--input`.
- `test_cli_version` and `test_cli_help` both pass locally.