### PR TITLE
fix: anchor callee inference at the attribute name, not the call-expression start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Attribute-call callees (`receiver.method(...)`) now resolve to the invoked method instead of the receiver's type — Jedi inference was anchored at the call expression's first character, i.e. the receiver token, so nearly every method call's `callee_signature` (and the Neo4j `PY_RESOLVES_TO` edge) pointed at the receiver's class ([#80](https://github.com/codellm-devkit/codeanalyzer-python/issues/80)).
+- `PyCallsite.return_type` now holds the inferred type of the call *result* (the callee's inferred return type, or the instance for a constructor call), and is absent when Jedi cannot tell. Previously it held the type inferred at the call expression's start — effectively the receiver's type ([#80](https://github.com/codellm-devkit/codeanalyzer-python/issues/80)).
+
 ## [0.3.0] - 2026-06-27
 
 ### Added

--- a/codeanalyzer/syntactic_analysis/symbol_table_builder.py
+++ b/codeanalyzer/syntactic_analysis/symbol_table_builder.py
@@ -114,6 +114,27 @@ class SymbolTableBuilder:
             return func_expr.end_lineno, func_expr.end_col_offset - 1
         return node.lineno, node.col_offset
 
+    @staticmethod
+    def _infer_call_return_type(script: Script, line: int, column: int) -> Optional[str]:
+        """Inferred type of the call's *result*, not of the callee itself.
+
+        ``Script.infer`` at the callee name yields the function/class
+        being called; executing that definition yields what the call
+        evaluates to — a function's inferred return type, or the
+        instance for a constructor call. Returns ``None`` when Jedi
+        can't tell, so an unknown stays absent instead of masquerading
+        as the callee's own name.
+        """
+        try:
+            definitions = script.infer(line=line, column=column)
+            if definitions:
+                results = definitions[0].execute()
+                if results:
+                    return results[0].name
+        except Exception:
+            pass
+        return None
+
     def build_pymodule_from_file(self, py_file: Path) -> PyModule:
         """Builds a PyModule from a Python file.
 
@@ -609,7 +630,7 @@ class SymbolTableBuilder:
             callee_signature, is_constructor = self._infer_callee(
                 script, anchor_line, anchor_col
             )
-            return_type = self._infer_type(script, anchor_line, anchor_col)
+            return_type = self._infer_call_return_type(script, anchor_line, anchor_col)
 
             receiver_expr = None
             receiver_type = None

--- a/codeanalyzer/syntactic_analysis/symbol_table_builder.py
+++ b/codeanalyzer/syntactic_analysis/symbol_table_builder.py
@@ -97,6 +97,23 @@ class SymbolTableBuilder:
         except Exception:
             return None, False
 
+    @staticmethod
+    def _callee_anchor(node: ast.Call) -> Tuple[int, int]:
+        """Position of the callee *name* for Jedi inference.
+
+        An ``ast.Call``'s own ``lineno``/``col_offset`` is the first
+        character of the whole call expression — for an attribute call
+        ``receiver.method(...)`` that is the receiver token, and Jedi
+        would infer the receiver's type instead of the invoked method
+        (issue #80). Anchor attribute calls inside the attribute name —
+        its last character, so one-character names stay in range; other
+        callee shapes keep the call-expression start.
+        """
+        func_expr = node.func
+        if isinstance(func_expr, ast.Attribute):
+            return func_expr.end_lineno, func_expr.end_col_offset - 1
+        return node.lineno, node.col_offset
+
     def build_pymodule_from_file(self, py_file: Path) -> PyModule:
         """Builds a PyModule from a Python file.
 
@@ -588,10 +605,11 @@ class SymbolTableBuilder:
             func_expr = node.func
 
             method_name = "<unknown>"
+            anchor_line, anchor_col = self._callee_anchor(node)
             callee_signature, is_constructor = self._infer_callee(
-                script, node.lineno, node.col_offset
+                script, anchor_line, anchor_col
             )
-            return_type = self._infer_type(script, node.lineno, node.col_offset)
+            return_type = self._infer_type(script, anchor_line, anchor_col)
 
             receiver_expr = None
             receiver_type = None

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -64,3 +64,9 @@ def whole_applications__flask() -> Path:
 def whole_applications__requests() -> Path:
     """Requests 2.31.0 application directory."""
     return Path(__file__).parent.resolve().joinpath("fixtures", "whole_applications", "requests")
+
+
+@pytest.fixture
+def single_functionalities__method_call_resolution() -> Path:
+    """Attribute-call callee resolution (issue #80): subscript receiver, inherited method, bare calls."""
+    return Path(__file__).parent.resolve().joinpath("fixtures", "single_functionalities", "method_call_resolution")

--- a/test/fixtures/single_functionalities/method_call_resolution/main.py
+++ b/test/fixtures/single_functionalities/method_call_resolution/main.py
@@ -1,0 +1,20 @@
+class Environment:
+    def __getitem__(self, name):
+        return Model()
+
+
+class Model:
+    env = Environment()
+
+    def search(self, domain):
+        return []
+
+    def helper(self):
+        return 42
+
+
+class AccountMove(Model):
+    def action_post(self):
+        accounts = self.env['account.account'].search([])
+        self.helper()
+        return str(len(accounts))

--- a/test/test_symbol_table_builder.py
+++ b/test/test_symbol_table_builder.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from codeanalyzer.syntactic_analysis.symbol_table_builder import SymbolTableBuilder
+
+
+def _action_post_call_sites(project_dir: Path):
+    builder = SymbolTableBuilder(project_dir, None)
+    module = builder.build_pymodule_from_file(project_dir / "main.py")
+    account_move = next(c for c in module.classes.values() if c.name == "AccountMove")
+    return {cs.method_name: cs for cs in account_move.methods["action_post"].call_sites}
+
+
+def test_attribute_calls_resolve_to_the_invoked_method(single_functionalities__method_call_resolution):
+    call_sites = _action_post_call_sites(single_functionalities__method_call_resolution)
+
+    assert call_sites["search"].callee_signature == "main.Model.search"
+    assert call_sites["helper"].callee_signature == "main.Model.helper"
+
+
+def test_attribute_calls_never_bind_to_the_enclosing_class(single_functionalities__method_call_resolution):
+    call_sites = _action_post_call_sites(single_functionalities__method_call_resolution)
+
+    assert all(
+        cs.callee_signature != "main.AccountMove" for cs in call_sites.values()
+    ), {name: cs.callee_signature for name, cs in call_sites.items()}
+
+
+def test_bare_name_calls_keep_their_resolution(single_functionalities__method_call_resolution):
+    call_sites = _action_post_call_sites(single_functionalities__method_call_resolution)
+
+    assert call_sites["len"].callee_signature == "builtins.len"
+    assert call_sites["len"].is_constructor_call is False
+    assert call_sites["str"].callee_signature == "builtins.str.__init__"
+    assert call_sites["str"].is_constructor_call is True

--- a/test/test_symbol_table_builder.py
+++ b/test/test_symbol_table_builder.py
@@ -32,3 +32,12 @@ def test_bare_name_calls_keep_their_resolution(single_functionalities__method_ca
     assert call_sites["len"].is_constructor_call is False
     assert call_sites["str"].callee_signature == "builtins.str.__init__"
     assert call_sites["str"].is_constructor_call is True
+
+
+def test_call_return_types_reflect_the_call_result(single_functionalities__method_call_resolution):
+    call_sites = _action_post_call_sites(single_functionalities__method_call_resolution)
+
+    assert call_sites["search"].return_type == "list"
+    assert call_sites["helper"].return_type == "int"
+    assert call_sites["len"].return_type == "int"
+    assert call_sites["str"].return_type == "str"


### PR DESCRIPTION
## Summary

`_infer_callee` (and the adjacent `return_type` inference) anchored Jedi at the `ast.Call` node's own position — the first character of the whole call expression. For any attribute call `receiver.method(...)` that is the receiver token, so Jedi inferred the *receiver's* type: every method call resolved to its receiver's class. In the external Odoo audit this produced 52,483/59,523 name-mismatched `PY_RESOLVES_TO` targets and bound 99.93% of `env[...]` calls to the caller's own enclosing class (CLDK-001/CLDK-002).

## Fix

- **`SymbolTableBuilder._callee_anchor`** — `ast.Attribute` callees anchor inside the attribute name (`func_expr.end_lineno`, `end_col_offset - 1`); all other callee shapes keep the call-expression start, so bare-name calls are byte-identical to before.
- **`SymbolTableBuilder._infer_call_return_type`** — callsite `return_type` now holds the call *result*'s inferred type (Jedi `Name.execute()` on the inferred callee: a function's return type, or the instance for a constructor call), and is absent when Jedi can't tell. Previously it held the type inferred at the call-expression start — effectively the receiver's type.
- Value-level fix only — no schema change (labels, relationship types, and properties untouched).

## Testing

- New fixture `test/fixtures/single_functionalities/method_call_resolution/` (subscript receiver via `__getitem__`, inherited method on `self`, bare-name and constructor calls) + `test/test_symbol_table_builder.py` (4 tests). Before the fix, the attribute-call tests fail with both calls bound to `main.AccountMove`; after, `search` → `main.Model.search`, `helper` → `main.Model.helper` (resolved through `__getitem__` and the MRO respectively).
- Full suite: 39 passed, 4 skipped, coverage 74.45% (gate 40%).
- CHANGELOG entry included under `[Unreleased]`.

Fixes #80. The v2-chain counterpart is tracked separately in #87 (forward-port of this anchor fix + L2 gate extension).
