### PR TITLE
fix: normalize project_dir to an absolute path in SymbolTableBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Attribute-call callees (`receiver.method(...)`) now resolve to the invoked method instead of the receiver's type — Jedi inference was anchored at the call expression's first character, i.e. the receiver token, so nearly every method call's `callee_signature` (and the Neo4j `PY_RESOLVES_TO` edge) pointed at the receiver's class ([#80](https://github.com/codellm-devkit/codeanalyzer-python/issues/80)).
 - `PyCallsite.return_type` now holds the inferred type of the call *result* (the callee's inferred return type, or the instance for a constructor call), and is absent when Jedi cannot tell. Previously it held the type inferred at the call expression's start — effectively the receiver's type ([#80](https://github.com/codellm-devkit/codeanalyzer-python/issues/80)).
+- `SymbolTableBuilder` no longer crashes with `ValueError` when given a relative `project_dir`: the path is normalized with `os.path.abspath` at construction (symlinks intact, matching Jedi's own path normalization) ([#90](https://github.com/codellm-devkit/codeanalyzer-python/issues/90)).
 
 ## [0.3.0] - 2026-06-27
 

--- a/codeanalyzer/syntactic_analysis/symbol_table_builder.py
+++ b/codeanalyzer/syntactic_analysis/symbol_table_builder.py
@@ -1,5 +1,6 @@
 import ast
 import hashlib
+import os
 import tokenize
 from ast import AST, ClassDef
 from io import StringIO
@@ -28,7 +29,11 @@ class SymbolTableBuilder:
     """A class for building a symbol table for a Python project."""
 
     def __init__(self, project_dir: Union[Path, str], virtualenv: Union[Path, str, None]) -> None:
-        self.project_dir = Path(project_dir)
+        # Jedi reports absolute Script paths, so a relative project_dir would
+        # crash every relative_to() fallback below. abspath (not resolve())
+        # keeps symlinks intact, matching Jedi's own absolute()-style
+        # normalization under symlinked roots like macOS /tmp.
+        self.project_dir = Path(os.path.abspath(project_dir))
         if virtualenv is None:
             # If no virtual environment is provided, create a jedi project without an environment.
             self.jedi_project: Project = jedi.Project(path=self.project_dir)

--- a/test/test_symbol_table_builder.py
+++ b/test/test_symbol_table_builder.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from codeanalyzer.syntactic_analysis.symbol_table_builder import SymbolTableBuilder
@@ -41,3 +42,13 @@ def test_call_return_types_reflect_the_call_result(single_functionalities__metho
     assert call_sites["helper"].return_type == "int"
     assert call_sites["len"].return_type == "int"
     assert call_sites["str"].return_type == "str"
+
+
+def test_builder_accepts_a_relative_project_dir(single_functionalities__method_call_resolution):
+    relative_dir = Path(os.path.relpath(single_functionalities__method_call_resolution, Path.cwd()))
+    assert not relative_dir.is_absolute()
+
+    call_sites = _action_post_call_sites(relative_dir)
+
+    assert call_sites["search"].callee_signature == "main.Model.search"
+    assert call_sites["helper"].callee_signature == "main.Model.helper"


### PR DESCRIPTION
## Summary

Constructing `SymbolTableBuilder` with a **relative** `project_dir` crashed analysis of any file containing a class: Jedi reports absolute `Script` paths, so the eagerly evaluated `relative_to()` fallback in `_add_class` (a `next()` default argument) raised `ValueError` inside the `try`, and the `except` handler recomputed the identical expression and raised uncaught. Pre-existing on `main` (byte-identical at 2cab542); discovered while verifying #89.

## Fix

Normalize once at the boundary: `self.project_dir = Path(os.path.abspath(project_dir))` in `__init__`. This fixes every downstream `relative_to()` (`_add_class`, `_callables`) in one place.

`os.path.abspath` rather than `Path.resolve()` deliberately: Jedi normalizes `Script.path` with `Path.absolute()` (symlinks intact), so `resolve()` would *break* currently-working analyses under symlinked roots (e.g. macOS `/tmp` → `/private/tmp`) by resolving one side of the comparison and not the other. `abspath` absolutizes and collapses `..` while preserving symlinks — matching Jedi.

## Testing

- New regression test `test_builder_accepts_a_relative_project_dir` (builds the `method_call_resolution` fixture through a cwd-relative path). Fails on the base commit with the exact #90 `ValueError`; passes after the fix.
- Full suite: 40 passed, 4 skipped, coverage 74.46% (gate 40%).
- CHANGELOG entry added under `[Unreleased]`.

Fixes #90.

**Stacked on #89** (`fix/issue-80-callee-anchoring`) — the regression test reuses that branch's fixture and test module. GitHub will retarget this PR to `main` automatically when #89 merges and its branch is deleted; review only the last commit (`6a676c5`) here.
