### PR TITLE
fix: deliver the stranded #90 relative-project_dir fix to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Attribute-call callees (`receiver.method(...)`) now resolve to the invoked method instead of the receiver's type — Jedi inference was anchored at the call expression's first character, i.e. the receiver token, so nearly every method call's `callee_signature` (and the Neo4j `PY_RESOLVES_TO` edge) pointed at the receiver's class ([#80](https://github.com/codellm-devkit/codeanalyzer-python/issues/80)).
 - `PyCallsite.return_type` now holds the inferred type of the call *result* (the callee's inferred return type, or the instance for a constructor call), and is absent when Jedi cannot tell. Previously it held the type inferred at the call expression's start — effectively the receiver's type ([#80](https://github.com/codellm-devkit/codeanalyzer-python/issues/80)).
+- `SymbolTableBuilder` no longer crashes with `ValueError` when given a relative `project_dir`: the path is normalized with `os.path.abspath` at construction (symlinks intact, matching Jedi's own path normalization) ([#90](https://github.com/codellm-devkit/codeanalyzer-python/issues/90)).
 
 ## [0.3.0] - 2026-06-27
 

--- a/codeanalyzer/syntactic_analysis/symbol_table_builder.py
+++ b/codeanalyzer/syntactic_analysis/symbol_table_builder.py
@@ -1,5 +1,6 @@
 import ast
 import hashlib
+import os
 import tokenize
 from ast import AST, ClassDef
 from io import StringIO
@@ -28,7 +29,11 @@ class SymbolTableBuilder:
     """A class for building a symbol table for a Python project."""
 
     def __init__(self, project_dir: Union[Path, str], virtualenv: Union[Path, str, None]) -> None:
-        self.project_dir = Path(project_dir)
+        # Jedi reports absolute Script paths, so a relative project_dir would
+        # crash every relative_to() fallback below. abspath (not resolve())
+        # keeps symlinks intact, matching Jedi's own absolute()-style
+        # normalization under symlinked roots like macOS /tmp.
+        self.project_dir = Path(os.path.abspath(project_dir))
         if virtualenv is None:
             # If no virtual environment is provided, create a jedi project without an environment.
             self.jedi_project: Project = jedi.Project(path=self.project_dir)

--- a/test/test_symbol_table_builder.py
+++ b/test/test_symbol_table_builder.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from codeanalyzer.syntactic_analysis.symbol_table_builder import SymbolTableBuilder
@@ -41,3 +42,13 @@ def test_call_return_types_reflect_the_call_result(single_functionalities__metho
     assert call_sites["helper"].return_type == "int"
     assert call_sites["len"].return_type == "int"
     assert call_sites["str"].return_type == "str"
+
+
+def test_builder_accepts_a_relative_project_dir(single_functionalities__method_call_resolution):
+    relative_dir = Path(os.path.relpath(single_functionalities__method_call_resolution, Path.cwd()))
+    assert not relative_dir.is_absolute()
+
+    call_sites = _action_post_call_sites(relative_dir)
+
+    assert call_sites["search"].callee_signature == "main.Model.search"
+    assert call_sites["helper"].callee_signature == "main.Model.helper"


### PR DESCRIPTION
## Summary

Rescue of the #90 fix, which never reached `main`: PR #91 was stacked on `fix/issue-80-callee-anchoring` and merged into that branch *after* #89 had already merged to `main`, so commit `6a676c5` (relative `project_dir` normalization) was stranded on the feature branch. Issue #90 shows closed, but `main`'s `SymbolTableBuilder.__init__` still has the unnormalized `Path(project_dir)`.

This PR cherry-picks that single commit onto `main` unchanged: `os.path.abspath` normalization in `__init__` (symlinks intact, matching Jedi's `Path.absolute()` behavior — deliberately not `resolve()`), the regression test, and the CHANGELOG line.

## Testing

`test/test_symbol_table_builder.py`: 5 passed on this branch (the relative-path regression test fails on current `main` with the #90 `ValueError`).

Refs #90 (already closed; this delivers the fix to `main`).
