### PR TITLE
fix: strip only the terminal .py suffix in path-derived fallback signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Attribute-call callees (`receiver.method(...)`) now resolve to the invoked method instead of the receiver's type — Jedi inference was anchored at the call expression's first character, i.e. the receiver token, so nearly every method call's `callee_signature` (and the Neo4j `PY_RESOLVES_TO` edge) pointed at the receiver's class ([#80](https://github.com/codellm-devkit/codeanalyzer-python/issues/80)).
 - `PyCallsite.return_type` now holds the inferred type of the call *result* (the callee's inferred return type, or the instance for a constructor call), and is absent when Jedi cannot tell. Previously it held the type inferred at the call expression's start — effectively the receiver's type ([#80](https://github.com/codellm-devkit/codeanalyzer-python/issues/80)).
 - `SymbolTableBuilder` no longer crashes with `ValueError` when given a relative `project_dir`: the path is normalized with `os.path.abspath` at construction (symlinks intact, matching Jedi's own path normalization) ([#90](https://github.com/codellm-devkit/codeanalyzer-python/issues/90)).
+- Path-derived fallback signatures no longer corrupt module prefixes containing `.py` as a substring (`odoo/tools/pycompat.py` → `odoo.toolscompat`): only the terminal `.py` suffix is stripped, via a single `_fallback_signature` helper replacing three copies of the buggy expression ([#84](https://github.com/codellm-devkit/codeanalyzer-python/issues/84)).
 
 ## [0.3.0] - 2026-06-27
 

--- a/codeanalyzer/syntactic_analysis/symbol_table_builder.py
+++ b/codeanalyzer/syntactic_analysis/symbol_table_builder.py
@@ -44,6 +44,16 @@ class SymbolTableBuilder:
                 environment_path=Path(virtualenv) / "bin" / "python",
             )
 
+    def _fallback_signature(self, script_path: Union[Path, str], name: str) -> str:
+        """Path-derived qualified name used when Jedi can't name a definition.
+
+        Strips only the terminal ``.py`` suffix — a bare ``str.replace``
+        would also eat interior ``.py`` substrings and corrupt the module
+        prefix (``odoo/tools/pycompat.py`` → ``odoo.toolscompat``).
+        """
+        relative = Path(script_path).relative_to(self.project_dir)
+        return ".".join(relative.with_suffix("").parts) + f".{name}"
+
     @staticmethod
     def _infer_type(script: Script, line: int, column: int) -> str:
         """Tries to infer the type at a given position using Jedi."""
@@ -246,10 +256,10 @@ class SymbolTableBuilder:
                     definitions = script.goto(line=start_line, column=child.col_offset)
                     signature = next(
                         (d.full_name for d in definitions if d.type == "class"),
-                        f"{Path(script.path).relative_to(self.project_dir).__str__().replace('/', '.').replace('.py', '')}.{class_name}"
+                        self._fallback_signature(script.path, class_name),
                     )
                 except Exception:
-                    signature = f"{Path(script.path).relative_to(self.project_dir).__str__().replace('/', '.').replace('.py', '')}.{class_name}"
+                    signature = self._fallback_signature(script.path, class_name)
             py_class = (
                 PyClass.builder()
                 .name(class_name)
@@ -301,8 +311,7 @@ class SymbolTableBuilder:
                     
                     # If Jedi didn't provide a signature, build one relative to project_dir
                     if not signature:
-                        relative_path = Path(script.path).relative_to(self.project_dir)
-                        signature = f"{str(relative_path).replace('/', '.').replace('.py', '')}.{method_name}"
+                        signature = self._fallback_signature(script.path, method_name)
                 py_callable = (
                     PyCallable.builder()
                     .name(method_name)  # Use the actual method name, not the full signature

--- a/test/test_symbol_table_builder.py
+++ b/test/test_symbol_table_builder.py
@@ -52,3 +52,15 @@ def test_builder_accepts_a_relative_project_dir(single_functionalities__method_c
 
     assert call_sites["search"].callee_signature == "main.Model.search"
     assert call_sites["helper"].callee_signature == "main.Model.helper"
+
+
+def test_fallback_signatures_strip_only_the_py_suffix(tmp_path):
+    builder = SymbolTableBuilder(tmp_path, None)
+
+    cases = {
+        "odoo/tools/babel/python_extractor.py": "odoo.tools.babel.python_extractor.extract",
+        "odoo/_monkeypatches/pytz.py": "odoo._monkeypatches.pytz.extract",
+        "odoo/tools/pycompat.py": "odoo.tools.pycompat.extract",
+    }
+    for relative_path, expected in cases.items():
+        assert builder._fallback_signature(tmp_path / relative_path, "extract") == expected


### PR DESCRIPTION
## Summary

Fixes CLDK-005 from the external Odoo audit: 8 signatures were corrupted because the path-derived fallback did `str.replace('.py', '')`, which removes **every** `.py` occurrence, not just the file suffix:

| path | corrupted | correct |
| --- | --- | --- |
| `odoo/tools/pycompat.py` | `odoo.toolscompat` | `odoo.tools.pycompat` |
| `odoo/_monkeypatches/pytz.py` | `odoo._monkeypatchestz` | `odoo._monkeypatches.pytz` |
| `odoo/tools/babel/python_extractor.py` | `odoo.tools.babelthon_extractor` | `odoo.tools.babel.python_extractor` |

## Fix

The expression existed as three verbatim copies (two in `_add_class`, one in `_callables`). They now share one `_fallback_signature` helper that strips only the terminal suffix (`Path.with_suffix("")` + joining `parts` — also drops the unix-path assumption of the old `replace('/', '.')`).

The fallback only triggers when Jedi's `goto` can't name a definition, which is why the corruption can't be forced end-to-end from a normal fixture; the regression test pins the helper directly with the three audited paths.

## Testing

- New `test_fallback_signatures_strip_only_the_py_suffix` (fails pre-fix with `AttributeError`, i.e. contract-first; the three audited corruptions are the assertions).
- Full suite: 41 passed, 4 skipped, coverage gate met.
- CHANGELOG entry under `[Unreleased]`.

Fixes #84. The v2 chain carries the same three sites (`symbol_table_builder.py:217/220/281` on `feat/v2-stage5-docs-release`); that forward-port rides with the #87 batch.

**Stacked on #92** (the #90-rescue branch, shared test-file tail). **Merge order: #92 first, then this** — after #92 merges and its branch is deleted, GitHub retargets this PR to `main` automatically.
