### PR TITLE
chore: add GEMINI.md symlink to CLAUDE.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
Closes #65.

The substance of #65 already landed with the schema-v2 chain (3ccaacd, released in 1.0.0): `CLAUDE.md` carries the full agent guidance and `AGENTS.md` symlinks to it. The one deliverable never carried over was the `GEMINI.md` symlink — this adds it, so all three agent entry points read the same file.