### PR TITLE
feat(cli)!: drop msgpack output; enforce --emit neo4j full-depth contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING: the msgpack output format is removed** (#118, TS parity): the
+  `--format msgpack` CLI choice, the `analysis.msgpack` artifact, the msgpack
+  serialization mixin on schema models, and the `msgpack` dependency are gone.
+  `analysis.json` is the single wire format; anyone passing `--format msgpack`
+  must drop the flag. `--format json` still works unchanged.
+- **`--emit neo4j` now enforces its always-full-depth contract** (#119): it
+  runs at level 4 with every graph section regardless of defaults, and
+  explicitly passing `-a`/`--graphs` alongside it is now the documented
+  explicit error (previously accepted silently — and worse, the emission
+  actually ran at the default level 1, producing a partial graph). Passing
+  `--graphs` below `-a 3` is also now consistently rejected even when the
+  value equals the default.
+
 ## [1.1.1] - 2026-07-27
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,8 +135,8 @@ declared callables by their `can://` tree id, imported/builtin targets by a
 
 ### Two projections
 
-1. **`analysis.json`** — the tree itself (the `Analysis` envelope above), also
-   available as gzip'd msgpack.
+1. **`analysis.json`** — the tree itself (the `Analysis` envelope above); the
+   single wire format (the msgpack variant was removed in 1.2.0, #118).
 2. **Neo4j** (`codeanalyzer/neo4j/`) — a near-identity projection, keyed on the
    same `can://` / global ordinal ids: containment → typed `PY_HAS_*` /
    `PY_DECLARES` edges (`PY_HAS_MODULE`, `PY_DECLARES`, `PY_HAS_METHOD`,

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ needs.
   checked in as `schema.neo4j.json` (`2.0.0`) and shipped with every release.
 - **Incremental cache** — per-file results are cached under `.codeanalyzer`; `--lazy` (default)
   reuses them, `--eager` forces a clean rebuild. `--ray` distributes the work across cores.
-- **Compact output** — canonical `analysis.json`, or binary `analysis.msgpack` for smaller artifacts.
+- **Compact output** — one canonical `analysis.json` per run.
 
 ## Installation
 
@@ -143,8 +143,7 @@ canpy --input /path/to/python/project
 ```
 
 With no `--output`, the analysis is printed to stdout as compact JSON; with `--output <dir>` it is
-written to `analysis.json` (or `graph.cypher` for `--emit neo4j`, or `analysis.msgpack` with
-`--format msgpack`) in that directory.
+written to `analysis.json` (or `graph.cypher` for `--emit neo4j`) in that directory.
 
 ### Options
 

--- a/codeanalyzer/__main__.py
+++ b/codeanalyzer/__main__.py
@@ -85,7 +85,7 @@ def main(
         typer.Option(
             "-f",
             "--format",
-            help="Output format for --emit json: json or msgpack.",
+            help="Output format for --emit json: json.",
             case_sensitive=False,
         ),
     ] = OutputFormat.JSON,
@@ -141,26 +141,31 @@ def main(
         ),
     ] = None,
     analysis_level: Annotated[
-        int,
+        Optional[int],
         typer.Option(
             "-a",
             "--analysis-level",
             help="Analysis depth: 1=symbol table+Jedi call graph, 2=+PyCG call "
             "graph, 3=+native intraprocedural dataflow (CFG/PDG), "
-            "4=+interprocedural SDG (param/summary edges, alias-aware DDG).",
+            "4=+interprocedural SDG (param/summary edges, alias-aware DDG). "
+            "[default: 1; incompatible with --emit neo4j, which is always "
+            "full-depth]",
             min=1,
             max=4,
+            show_default="1",
         ),
-    ] = 1,
+    ] = None,
     graphs: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--graphs",
             help="Level 3+ only: comma-separated program-graph sections to emit "
             "(cfg, dfg, pdg, sdg). Default: cfg,dfg,pdg. `dfg` emits the PDG's data "
-            "edges only; `sdg` requires -a 4.",
+            "edges only; `sdg` requires -a 4. Incompatible with --emit neo4j "
+            "(always full-depth).",
+            show_default="cfg,dfg,pdg",
         ),
-    ] = "cfg,dfg,pdg",
+    ] = None,
     graph_field_depth: Annotated[
         int,
         typer.Option(
@@ -300,8 +305,39 @@ def main(
     _pin_hash_seed()
 
     # Flag validation (strict: unrecognized values error out, never fall back).
-    selected_graphs = [g.strip() for g in graphs.split(",") if g.strip()]
+    # -a and --graphs use None sentinels so an explicitly-passed flag is
+    # distinguishable from the default (#119).
+    explicit_level = analysis_level is not None
+    explicit_graphs = graphs is not None
+
+    # Neo4j is always full-depth (#119): the graph carries every level's
+    # facts, so depth/section selectors cannot be combined with it — reject
+    # explicitly-passed flags and force level 4 with every graph section.
     from codeanalyzer.dataflow.builder import VALID_GRAPHS
+
+    if emit == EmitTarget.NEO4J:
+        explicit = [
+            flag
+            for flag, was_explicit in (
+                ("-a/--analysis-level", explicit_level),
+                ("--graphs", explicit_graphs),
+            )
+            if was_explicit
+        ]
+        if explicit:
+            logger.error(
+                "--emit neo4j is always full-depth (level 4, all graph "
+                f"sections); {' and '.join(explicit)} cannot be combined with it."
+            )
+            raise typer.Exit(code=2)
+        analysis_level = 4
+        graphs = ",".join(VALID_GRAPHS)
+
+    if analysis_level is None:
+        analysis_level = 1
+    if graphs is None:
+        graphs = "cfg,dfg,pdg"
+    selected_graphs = [g.strip() for g in graphs.split(",") if g.strip()]
 
     unknown_graphs = [g for g in selected_graphs if g not in VALID_GRAPHS]
     if unknown_graphs:
@@ -316,7 +352,7 @@ def main(
     if "sdg" in selected_graphs and analysis_level < 4:
         logger.error("--graphs sdg requires -a 4 (interprocedural SDG).")
         raise typer.Exit(code=2)
-    if analysis_level < 3 and graphs != "cfg,dfg,pdg":
+    if analysis_level < 3 and explicit_graphs:
         logger.error("--graphs is a level-3 option; pass -a 3 to emit program graphs.")
         raise typer.Exit(code=2)
     if analysis_level < 3 and graph_field_depth != 3:
@@ -407,16 +443,6 @@ def _write_output(artifacts, output_dir: Path, format: OutputFormat):
         with output_file.open("w") as f:
             f.write(json_str)
         logger.info(f"Analysis saved to {output_file}")
-
-    elif format == OutputFormat.MSGPACK:
-        output_file = output_dir / "analysis.msgpack"
-        msgpack_data = artifacts.to_msgpack_bytes()
-        with output_file.open("wb") as f:
-            f.write(msgpack_data)
-        logger.info(f"Analysis saved to {output_file}")
-        logger.info(
-            f"Compression ratio: {artifacts.get_compression_ratio():.1%} of JSON size"
-        )
 
 
 app = typer.Typer(

--- a/codeanalyzer/config/config.py
+++ b/codeanalyzer/config/config.py
@@ -5,4 +5,3 @@ class OutputFormat(str, Enum):
     """String-based enum for output formats to support typer case-insensitive options."""
 
     JSON = "json"
-    MSGPACK = "msgpack"

--- a/codeanalyzer/options/options.py
+++ b/codeanalyzer/options/options.py
@@ -6,7 +6,6 @@ from enum import Enum
 
 class OutputFormat(str, Enum):
     JSON = "json"
-    MSGPACK = "msgpack"
 
 
 class EmitTarget(str, Enum):

--- a/codeanalyzer/schema/py_schema.py
+++ b/codeanalyzer/schema/py_schema.py
@@ -22,85 +22,8 @@ for static analysis purposes.
 from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-import gzip
-
 from pydantic import BaseModel
 from typing_extensions import Literal
-import msgpack
-
-
-def msgpk(cls):
-    """
-    Decorator that adds MessagePack serialization methods to Pydantic models.
-
-    Adds methods:
-        - to_msgpack_bytes() -> bytes: Serialize to compact binary format
-        - from_msgpack_bytes(data: bytes) -> cls: Deserialize from binary format
-        - to_msgpack_dict() -> dict: Convert to msgpack-compatible dict
-        - from_msgpack_dict(data: dict) -> cls: Create instance from msgpack dict
-    """
-
-    def _prepare_for_serialization(obj: Any) -> Any:
-        """Convert objects to serialization-friendly format."""
-        if isinstance(obj, Path):
-            return str(obj)
-        elif isinstance(obj, dict):
-            return {
-                _prepare_for_serialization(k): _prepare_for_serialization(v)
-                for k, v in obj.items()
-            }
-        elif isinstance(obj, list):
-            return [_prepare_for_serialization(item) for item in obj]
-        elif isinstance(obj, tuple):
-            return tuple(_prepare_for_serialization(item) for item in obj)
-        elif isinstance(obj, set):
-            return [_prepare_for_serialization(item) for item in obj]
-        elif hasattr(obj, "model_dump"):  # Pydantic model
-            return _prepare_for_serialization(obj.model_dump())
-        else:
-            return obj
-
-    def to_msgpack_bytes(self) -> bytes:
-        """Serialize the model to compact binary format using MessagePack + gzip."""
-        data = _prepare_for_serialization(self.model_dump())
-        msgpack_data = msgpack.packb(data, use_bin_type=True)
-        return gzip.compress(msgpack_data)
-
-    @classmethod
-    def from_msgpack_bytes(cls_obj, data: bytes):
-        """Deserialize from MessagePack + gzip binary format."""
-        decompressed_data = gzip.decompress(data)
-        obj_dict = msgpack.unpackb(decompressed_data, raw=False)
-        return cls_obj.model_validate(obj_dict)
-
-    def to_msgpack_dict(self) -> dict:
-        """Convert to msgpack-compatible dictionary format."""
-        return _prepare_for_serialization(self.model_dump())
-
-    @classmethod
-    def from_msgpack_dict(cls_obj, data: dict):
-        """Create instance from msgpack-compatible dictionary."""
-        return cls_obj.model_validate(data)
-
-    def get_msgpack_size(self) -> int:
-        """Get the size of the msgpack serialization in bytes."""
-        return len(self.to_msgpack_bytes())
-
-    def get_compression_ratio(self) -> float:
-        """Get compression ratio compared to JSON."""
-        json_size = len(self.model_dump_json().encode("utf-8"))
-        msgpack_gzip_size = self.get_msgpack_size()
-        return msgpack_gzip_size / json_size if json_size > 0 else 1.0
-
-    # Add methods to the class
-    cls.to_msgpack_bytes = to_msgpack_bytes
-    cls.from_msgpack_bytes = from_msgpack_bytes
-    cls.to_msgpack_dict = to_msgpack_dict
-    cls.from_msgpack_dict = from_msgpack_dict
-    cls.get_msgpack_size = get_msgpack_size
-    cls.get_compression_ratio = get_compression_ratio
-
-    return cls
 
 
 def builder(cls):
@@ -192,7 +115,6 @@ def byte_offsets(source: str, start_line: int, start_col: int,
 
 
 @builder
-@msgpk
 class Span(BaseModel):
     """Where a node lives in source. `start`/`end` are [line, col] (1-based line,
     0-based col, ast semantics); `bytes` are utf-8 offsets into module.source."""
@@ -202,7 +124,6 @@ class Span(BaseModel):
 
 
 @builder
-@msgpk
 class BodyNode(BaseModel):
     """A node in a callable's `body`: an AST region (statement/call/branch/…) or
     a synthetic analysis vertex (entry/exit/formal_in/out/actual_in/out)."""
@@ -214,37 +135,31 @@ class BodyNode(BaseModel):
 
 
 @builder
-@msgpk
 class CfgEdge(BaseModel):
     src: str; dst: str; kind: str = "fallthrough"
 
 
 @builder
-@msgpk
 class CdgEdge(BaseModel):
     src: str; dst: str
 
 
 @builder
-@msgpk
 class DdgEdge(BaseModel):
     src: str; dst: str; var: Optional[str] = None; prov: List[str] = []
 
 
 @builder
-@msgpk
 class SummaryEdge(BaseModel):
     src: str; dst: str
 
 
 @builder
-@msgpk
 class ParamEdge(BaseModel):
     src: str; dst: str
 
 
 @builder
-@msgpk
 class PyImport(BaseModel):
     """Represents a Python import statement."""
 
@@ -259,7 +174,6 @@ class PyImport(BaseModel):
 
 
 @builder
-@msgpk
 class PyComment(BaseModel):
     """Represents a Python comment."""
 
@@ -272,7 +186,6 @@ class PyComment(BaseModel):
 
 
 @builder
-@msgpk
 class PySymbol(BaseModel):
     """Represents a symbol used or declared in Python code."""
 
@@ -287,7 +200,6 @@ class PySymbol(BaseModel):
 
 
 @builder
-@msgpk
 class PyVariableDeclaration(BaseModel):
     """Represents a Python variable declaration."""
 
@@ -306,7 +218,6 @@ class PyVariableDeclaration(BaseModel):
 
 
 @builder
-@msgpk
 class PyCallableParameter(BaseModel):
     """Represents a parameter of a Python callable (function/method)."""
 
@@ -320,7 +231,6 @@ class PyCallableParameter(BaseModel):
 
 
 @builder
-@msgpk
 class PyCallArgument(BaseModel):
     """One call-site argument: AST category + inferred type, kept separate.
 
@@ -333,7 +243,6 @@ class PyCallArgument(BaseModel):
 
 
 @builder
-@msgpk
 class PyCallsite(BaseModel):
     """Represents a Python call site (function or method invocation) with contextual metadata."""
 
@@ -352,7 +261,6 @@ class PyCallsite(BaseModel):
 
 
 @builder
-@msgpk
 class PyCallable(BaseModel):
     """Represents a Python callable (function/method)."""
 
@@ -389,7 +297,6 @@ class PyCallable(BaseModel):
 
 
 @builder
-@msgpk
 class PyClassAttribute(BaseModel):
     """Represents a Python class attribute."""
 
@@ -402,7 +309,6 @@ class PyClassAttribute(BaseModel):
 
 
 @builder
-@msgpk
 class PyClass(BaseModel):
     """Represents a Python class."""
 
@@ -425,7 +331,6 @@ class PyClass(BaseModel):
 
 
 @builder
-@msgpk
 class PyModule(BaseModel):
     """Represents a Python module."""
 
@@ -446,7 +351,6 @@ class PyModule(BaseModel):
 
 
 @builder
-@msgpk
 class PyCallEdge(BaseModel):
     """Identity-only call-graph edge with weight (keystone shape: the list name
     IS the edge type, so there is no ``type`` field).
@@ -464,7 +368,6 @@ class PyCallEdge(BaseModel):
 
 
 @builder
-@msgpk
 class PyExternalSymbol(BaseModel):
     """A call-graph target outside the analyzed project -- an imported library or
     builtin member. An edge-endpoint id home, not a tree node: keyed in
@@ -477,7 +380,6 @@ class PyExternalSymbol(BaseModel):
 
 
 @builder
-@msgpk
 class PyRepositoryInfo(BaseModel):
     """Where the analyzed source came from: git provenance captured at analysis time."""
 
@@ -487,7 +389,6 @@ class PyRepositoryInfo(BaseModel):
 
 
 @builder
-@msgpk
 class PyAnalyzerInfo(BaseModel):
     """Which analyzer produced this snapshot, and how it was configured.
     Lives on the ``Analysis`` envelope (keystone ``analyzer{name,version}``;
@@ -499,7 +400,6 @@ class PyAnalyzerInfo(BaseModel):
 
 
 @builder
-@msgpk
 class PyApplication(BaseModel):
     """Represents a Python application."""
 
@@ -519,7 +419,6 @@ class PyApplication(BaseModel):
 
 
 @builder
-@msgpk
 class Analysis(BaseModel):
     """v2 payload root: envelope + the application tree node. ``k_limit`` is an
     L3+ envelope key (None below the dataflow levels; exclude_none drops it)."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,6 @@ dependencies = [
     # parso 0.8.5 is the first release shipping the Python 3.14 grammar; older
     # resolutions make jedi reject every file in a 3.14 analysis env (#107)
     "parso>=0.8.5",
-    # msgpack
-    "msgpack>=1.0.0,<1.0.7; python_version < '3.11'",
-    "msgpack>=1.0.7,<2.0.0; python_version >= '3.11'",
     # networkx
     "networkx>=2.6.0,<3.2.0; python_version < '3.11'",
     "networkx>=3.0.0,<4.0.0; python_version >= '3.11'",

--- a/test/test_cli_emit_gates.py
+++ b/test/test_cli_emit_gates.py
@@ -1,0 +1,97 @@
+"""Regression tests for #119 (Neo4j emission is always full-depth — enforced,
+not just documented) and #118 (the msgpack output format is gone).
+"""
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from codeanalyzer.__main__ import app
+
+_ENV = {"NO_COLOR": "1", "TERM": "dumb"}
+
+
+@pytest.fixture()
+def cli_runner():
+    return CliRunner()
+
+
+@pytest.fixture()
+def tiny_project(tmp_path):
+    proj = tmp_path / "tiny"
+    proj.mkdir()
+    (proj / "m.py").write_text(
+        "def g(x):\n    return x\n\n\ndef f(a):\n    b = g(a)\n    return b\n",
+        encoding="utf-8",
+    )
+    return proj
+
+
+def _invoke(cli_runner, *args):
+    return cli_runner.invoke(app, list(args), env=_ENV)
+
+
+# ----------------------------------------------------------------------------------------------
+# #119 — --emit neo4j is always full-depth.
+# ----------------------------------------------------------------------------------------------
+
+
+def test_emit_neo4j_rejects_explicit_analysis_level(cli_runner, tiny_project, tmp_path):
+    r = _invoke(
+        cli_runner,
+        "--input", str(tiny_project), "--output", str(tmp_path / "out"),
+        "--no-venv", "--emit", "neo4j", "-a", "2",
+    )
+    assert r.exit_code != 0, "--emit neo4j with an explicit -a must be an error"
+
+
+def test_emit_neo4j_rejects_explicit_graphs(cli_runner, tiny_project, tmp_path):
+    r = _invoke(
+        cli_runner,
+        "--input", str(tiny_project), "--output", str(tmp_path / "out"),
+        "--no-venv", "--emit", "neo4j", "--graphs", "cfg",
+    )
+    assert r.exit_code != 0, "--emit neo4j with an explicit --graphs must be an error"
+
+
+def test_emit_neo4j_runs_full_depth_by_default(cli_runner, tiny_project, tmp_path):
+    """Plain --emit neo4j must produce the FULL graph: the cypher snapshot has
+    to contain the L3/L4 families (PyCFGNode rows, PY_CFG_NEXT/PY_DDG edges,
+    param vertices), not just the L1 symbol table."""
+    out = tmp_path / "out"
+    r = _invoke(
+        cli_runner,
+        "--input", str(tiny_project), "--output", str(out),
+        "--no-venv", "--emit", "neo4j",
+    )
+    assert r.exit_code == 0, f"plain --emit neo4j must succeed: {r.output}"
+    cypher = (out / "graph.cypher").read_text()
+    for marker in ("PyCFGNode", "PY_CFG_NEXT", "PY_DDG", "formal_in"):
+        assert marker in cypher, (
+            f"full-depth neo4j emission must contain {marker}; "
+            "the graph appears to be shallow"
+        )
+
+
+# ----------------------------------------------------------------------------------------------
+# #118 — msgpack is gone.
+# ----------------------------------------------------------------------------------------------
+
+
+def test_format_msgpack_is_rejected(cli_runner, tiny_project, tmp_path):
+    r = _invoke(
+        cli_runner,
+        "--input", str(tiny_project), "--output", str(tmp_path / "out"),
+        "--no-venv", "--format", "msgpack",
+    )
+    assert r.exit_code != 0, "--format msgpack must no longer be accepted"
+
+
+def test_msgpack_absent_from_model_and_help(cli_runner):
+    r = _invoke(cli_runner, "--help")
+    assert "msgpack" not in r.output.lower()
+    from codeanalyzer.schema.py_schema import PyModule
+
+    assert not hasattr(PyModule, "to_msgpack_bytes"), (
+        "the msgpack serialization mixin must be removed"
+    )


### PR DESCRIPTION
Closes #118. Closes #119.

**#118 — msgpack removed (TS parity).** The `--format msgpack` choice, `analysis.msgpack` artifact, msgpack serialization mixin on schema models, and the `msgpack` dependency are gone; `analysis.json` is the single wire format. No consumer existed — the python-sdk reads JSON exclusively and the analysis cache was already plain JSON. **Breaking** for anyone passing `--format msgpack` (they drop the flag).

**#119 — neo4j full-depth contract enforced.** Triage found it worse than reported: `--emit neo4j` neither rejected `-a`/`--graphs` **nor forced full depth** — it silently emitted a partial graph at the default level 1. Now: `--emit neo4j` runs at level 4 with every graph section, and explicitly passing `-a`/`--graphs` alongside it is the documented error. Implementation detail: `-a`/`--graphs` use `None` sentinels because click's `get_parameter_source` misreports under the Typer group context; the sentinel pattern also closes a latent hole where an explicitly-passed default `--graphs` value below `-a 3` slipped validation. (TS already enforces exactly this gate — python was the outlier.)

**Tests:** 5 new regression tests (`test/test_cli_emit_gates.py`): both rejection paths, full-depth cypher content (`PyCFGNode`/`PY_CFG_NEXT`/`PY_DDG`/`formal_in` present), msgpack rejection, and mixin absence.

**Gate:** 203 passed, 6 skipped in 6m28s.

**Propagation:** none — TS is the parity baseline for both changes; the python-sdk has no msgpack usage; no external fixture encodes the old behaviors. Docs (README hand-sections, CLAUDE.md) updated in-PR; the README `--help` block regenerates at release. Related design question spun out as #120.

Ships as **1.2.0** (breaking flag removal + emission behavior change).