### PR TITLE
chore(deps): drop unused numpy and pandas dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   actually ran at the default level 1, producing a partial graph). Passing
   `--graphs` below `-a 3` is also now consistently rejected even when the
   value equals the default.
+- **`numpy` and `pandas` are no longer dependencies** (#124): neither was ever
+  imported by the analyzer, but both were declared in `[project].dependencies`
+  with tight upper caps (`numpy<1.24` below Python 3.11, `numpy<2.0` above it).
+  The caps forced resolution onto numpy releases with no prebuilt wheel for some
+  targets — Red Hat UBI images in particular — so installation fell back to
+  building numpy from source and failed. On Python 3.11+ numpy is now absent
+  from the resolved tree entirely (`ray` 2.55 does not require it). On Python
+  3.9/3.10 `ray==2.0.0` still requires numpy transitively — that pin is
+  untouched — but with the cap gone it resolves to numpy 2.0.2, which ships
+  cp39 manylinux wheels for x86_64 and aarch64, so the source build stops
+  happening there too.
 
 ## [1.1.1] - 2026-07-27
 

--- a/packaging/homebrew/generate_formula.sh
+++ b/packaging/homebrew/generate_formula.sh
@@ -4,7 +4,7 @@
 #
 # Unlike the codeanalyzer-typescript sibling -- which ships a single self-contained
 # binary that the formula just downloads -- codeanalyzer-python is a pure-Python
-# package published to PyPI with heavy native dependencies (ray, pandas, numpy).
+# package published to PyPI with a heavy native dependency (ray).
 # Vendoring every transitive dependency as a Homebrew `resource` is impractical
 # (ray is not buildable from an sdist), and pip-installing at build time is blocked
 # by Homebrew's network sandbox.
@@ -41,8 +41,8 @@ class CodeanalyzerPython < Formula
   version "${VERSION}"
   license "Apache-2.0"
 
-  # codeanalyzer-python is a pure-Python PyPI package with heavy native deps
-  # (ray, pandas, numpy). Rather than vendor every transitive dependency as a
+  # codeanalyzer-python is a pure-Python PyPI package with a heavy native dep
+  # (ray). Rather than vendor every transitive dependency as a
   # Homebrew resource, install the pinned PyPI release as an isolated uv tool;
   # uv resolves and caches the environment on first run.
   depends_on "uv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,6 @@ dependencies = [
     # networkx
     "networkx>=2.6.0,<3.2.0; python_version < '3.11'",
     "networkx>=3.0.0,<4.0.0; python_version >= '3.11'",
-    # pandas
-    "pandas>=1.3.0,<2.0.0; python_version < '3.11'",
-    "pandas>=2.0.0,<3.0.0; python_version >= '3.11'",
-    # numpy
-    "numpy>=1.21.0,<1.24.0; python_version < '3.11'",
-    "numpy>=1.24.0,<2.0.0; python_version >= '3.11' and python_version < '3.12'",
-    "numpy>=1.26.0,<2.0.0; python_version >= '3.12'",
     # pydantic
     "pydantic>=1.8.0,<2.0.0; python_version < '3.11'",
     "pydantic>=2.0.0,<3.0.0; python_version >= '3.11'",


### PR DESCRIPTION
Closes #124.

## What

Removes the `numpy` and `pandas` entries from `[project].dependencies`. Neither
is imported anywhere in the analyzer — `git grep -I "numpy\|pandas"` finds
first-party hits only in the vendored `xarray` test fixture and in comments in
`packaging/homebrew/generate_formula.sh` (also updated here).

## Why

The declarations carried tight upper caps (`numpy>=1.21.0,<1.24.0` below Python
3.11, `<2.0.0` above it). Those caps pinned installs to numpy releases with no
prebuilt wheel for some targets — Red Hat UBI images in particular — so
`pip install codeanalyzer-python` fell back to building numpy from source and
failed. Same failure class as #19, except this dependency buys nothing.

`pandas` was the only remaining route to numpy on modern interpreters: `ray`
2.55 declares no numpy dependency, so removing both drops numpy from the
resolved tree entirely on Python 3.11+.

## Verification

```
$ uv tree --python-version 3.12 | grep -i "numpy\|pandas"   # no output
$ uv tree --python-version 3.11 | grep -i "numpy\|pandas"   # no output
$ uv run python -c "import numpy"
ModuleNotFoundError: No module named 'numpy'
$ uv run python -c "import codeanalyzer"                    # ok
```

Full test suite run with numpy absent from the environment.

## Not in scope

On Python 3.9/3.10 the `ray==2.0.0` pin still pulls numpy in transitively, so
`uv tree --python-version 3.9` still reports `numpy v1.23.5`. Raising that ray
floor carries real compatibility risk and is deliberately left out.

The same change is backported to `release/0.3.x` and released as `0.3.2` for
consumers pinned to the 0.3 line.