### PR TITLE
fix(pycg): canonicalize the builtins module spelling on PyCG edges

### DIFF
--- a/codeanalyzer/semantic_analysis/pycg/pycg_analysis.py
+++ b/codeanalyzer/semantic_analysis/pycg/pycg_analysis.py
@@ -88,6 +88,44 @@ from codeanalyzer.semantic_analysis.pycg.shard_planner import plan_shards
 from codeanalyzer.utils import ProgressBar, logger
 
 
+# PyCG spells the builtins module ``<builtin>``; Jedi spells it ``builtins``. Left
+# unnormalized, one builtin gets two ``@external`` ``can://`` homes and the two
+# backends' edges can never coalesce, so a call both resolvers agree on can never
+# reach ``prov: ["jedi", "pycg"]`` (#132). PyCG only ever emits the bare module, so
+# an exact-match alias is enough -- the dotted forms (``builtins.str`` etc.) are
+# Jedi's and are already canonical.
+_PYCG_MODULE_ALIASES = {"<builtin>": "builtins"}
+
+
+def _canonical_endpoint(sig: str) -> str:
+    """Rewrite a PyCG endpoint's module segment to the canonical spelling."""
+    module, dot, name = sig.rpartition(".")
+    if dot and module in _PYCG_MODULE_ALIASES:
+        return f"{_PYCG_MODULE_ALIASES[module]}.{name}"
+    return sig
+
+
+def _canonicalize_edges(edges: List[PyCallEdge]) -> List[PyCallEdge]:
+    """Canonicalize endpoint spellings, coalescing pairs that collide as a result.
+
+    Two spellings of one target are one edge: weights sum and provenance unions,
+    matching ``call_graph.merge_edges``. Deliberately does not route through
+    ``_coalesce_edges``, which raises on its duplicate branch (#133).
+    """
+    merged: Dict[Tuple[str, str], PyCallEdge] = {}
+    for edge in edges:
+        src = _canonical_endpoint(edge.src)
+        dst = _canonical_endpoint(edge.dst)
+        key = (src, dst)
+        current = merged.get(key)
+        if current is None:
+            merged[key] = edge.model_copy(update={"src": src, "dst": dst})
+        else:
+            current.weight += edge.weight
+            current.prov = sorted(set(current.prov) | set(edge.prov))
+    return list(merged.values())
+
+
 def _shard_root_path(files: List[str], project_dir: Path) -> Path:
     """Content-derived mini-project root for a shard: same project + same file
     set → same path on every run (determinism, issue #99)."""
@@ -1110,6 +1148,7 @@ class PyCG:
             with _shard_symlink_root(entry_points, self.project_dir) as (root, eps):
                 edges = self._run_pycg_batch(eps, root, resolver, prefix="")
 
+        edges = _canonicalize_edges(edges)
         elapsed = time.perf_counter() - t0
         logger.info("✅ PyCG: %d edges in %.1fs", len(edges), elapsed)
         return edges

--- a/test/test_pycg_builtin_canonicalization.py
+++ b/test/test_pycg_builtin_canonicalization.py
@@ -1,0 +1,56 @@
+"""PyCG builtin module spelling is canonicalized before edges leave the backend (#132).
+
+PyCG spells the builtins module ``<builtin>``; Jedi spells it ``builtins``. Left
+unnormalized, one builtin gets two ``@external`` ``can://`` homes and the two
+backends' edges can never coalesce into ``prov: ["jedi", "pycg"]``.
+"""
+from codeanalyzer.schema.py_schema import PyCallEdge
+from codeanalyzer.semantic_analysis.call_graph import merge_edges
+from codeanalyzer.semantic_analysis.pycg.pycg_analysis import (
+    _canonical_endpoint,
+    _canonicalize_edges,
+)
+
+
+def test_builtin_module_is_rewritten():
+    assert _canonical_endpoint("<builtin>.isinstance") == "builtins.isinstance"
+    assert _canonical_endpoint("<builtin>.len") == "builtins.len"
+
+
+def test_already_canonical_and_unrelated_names_are_untouched():
+    for sig in (
+        "builtins.isinstance",     # Jedi's spelling, already canonical
+        "builtins.str.format",     # dotted builtin type -- module is `builtins.str`
+        "requests.api.get",        # ordinary first-party signature
+        "isinstance",              # no module segment at all
+        "<builtin>",               # bare, no dot -> not an endpoint we rewrite
+    ):
+        assert _canonical_endpoint(sig) == sig
+
+
+def test_colliding_spellings_coalesce_with_summed_weight():
+    edges = [
+        PyCallEdge(src="a.f", dst="<builtin>.len", weight=3, prov=["pycg"]),
+        PyCallEdge(src="a.f", dst="builtins.len", weight=2, prov=["pycg"]),
+    ]
+    out = _canonicalize_edges(edges)
+    assert len(out) == 1
+    assert (out[0].src, out[0].dst) == ("a.f", "builtins.len")
+    assert out[0].weight == 5
+
+
+def test_canonicalization_lets_provenance_merge_across_backends():
+    """The point of #132: without this, a builtin can never reach prov=[jedi,pycg]."""
+    pycg = _canonicalize_edges(
+        [PyCallEdge(src="a.f", dst="<builtin>.len", weight=1, prov=["pycg"])]
+    )
+    jedi = [PyCallEdge(src="a.f", dst="builtins.len", weight=1, prov=["jedi"])]
+    merged = merge_edges(jedi, pycg)
+    assert len(merged) == 1
+    assert merged[0].prov == ["jedi", "pycg"]
+
+
+def test_source_edges_are_not_mutated():
+    original = PyCallEdge(src="a.f", dst="<builtin>.len", weight=1, prov=["pycg"])
+    _canonicalize_edges([original])
+    assert original.dst == "<builtin>.len"


### PR DESCRIPTION
Closes #132.

## Problem

PyCG spells the builtins module `<builtin>`. Jedi spells it `builtins`. Same builtin, two `can://` ids.

`requests` fixture at `-a 2`, before the fix:

- 29 ids under `@external/<builtin>/` — all `prov=['pycg']`
- 14 ids under `@external/builtins/` — all `prov=['jedi']`
- 12 names in both: `len`, `isinstance`, `getattr`, `sorted`, `all`, `any`, `chr`, `hasattr`, `iter`, `max`, `print`, `setattr`

Two consequences.

**First.** Asking "who calls `len`" returns two disjoint answers. Neither is complete.

**Second.** `merge_edges` coalesces on `(src, dst)`. Different `dst` means the two backends never meet, so a builtin can never reach `prov: ["jedi", "pycg"]`. In the same run, 198 non-builtin edges do carry both — the merge works. Builtins are structurally locked out.

Root cause: `core.py:_home_external_symbols` splits the signature on its last dot, mints `@external/<module>/<name>`, and never canonicalizes `module`.

## Fix

Rewrite `<builtin>.x` to `builtins.x` at one place — the `PyCG.build_call_graph_edges` exit. Every shard strategy returns through it.

Placement matters:

- Must land **before** `merge_edges` (`core.py:598`), **not** at id-minting (`core.py:633`). A mint-time fix leaves two already-merged edges with identical endpoints and split provenance — the symptom moves rather than disappears.
- Endpoints that collide after the rewrite are coalesced: weights sum, provenance unions. Same semantics as `merge_edges`.
- Coalescing is done locally, **not** through `_coalesce_edges`. That one raises on its duplicate branch (#133), and this fix is what makes the branch reachable.

PyCG only ever emits the bare `<builtin>` module (69 occurrences across `requests` and `flask`). The dotted forms (`builtins.str`, `builtins.dict`) come from Jedi and are already canonical, so an exact-match alias suffices — no prefix rewriting.

## Verification

Both fixtures re-analyzed at `-a 2` on this branch:

| | requests | flask |
| --- | --- | --- |
| `<builtin>` ids left | **0** | **0** |
| `<builtin>` edges left | **0** | **0** |
| distinct `builtins/` names | 31 | 41 |
| builtin edges with `prov: ["jedi","pycg"]` | **74** (was 0) | **99** (was 0) |

31 = 29 + 14 − 12. The merge is exact: no id lost, none invented.

## Tests

`test/test_pycg_builtin_canonicalization.py`, five tests:

- `<builtin>.x` is rewritten
- already-canonical and unrelated names are untouched (`builtins.str.format`, first-party signatures, bare names, bare `<builtin>`)
- colliding spellings coalesce with summed weight
- end-to-end provenance merge — the point of the issue
- input edges are not mutated

## Caveats

Suite is green on a quiet machine: `198 passed, 2 skipped, 14 deselected in 6:30` — the 193 from `main` plus the 5 added here. An earlier run hung while a 3.5-hour `xarray` analysis held the machine; that was contention, not this diff. The suite is load-sensitive (PyCG shard timeouts under load produce spurious L2 failures), so it needs a quiet machine to mean anything.

Edge weights change where two spellings collapse into one. That is the correct new value, not a regression.
