### PR TITLE
fix(pycg): _coalesce_edges raised on every duplicate edge

### DIFF
--- a/codeanalyzer/semantic_analysis/pycg/pycg_analysis.py
+++ b/codeanalyzer/semantic_analysis/pycg/pycg_analysis.py
@@ -504,20 +504,21 @@ class PyCG:
 
     @staticmethod
     def _coalesce_edges(edges: List[PyCallEdge]) -> List[PyCallEdge]:
-        """Sum weights of duplicate ``(source, target)`` pairs across shards."""
+        """Sum weights of duplicate ``(src, dst)`` pairs across shards.
+
+        Provenance is the sorted union, matching ``call_graph.merge_edges`` --
+        the two must not coalesce differently. Inputs are left untouched; the
+        merged edge is a copy.
+        """
         merged: Dict[tuple, PyCallEdge] = {}
         for edge in edges:
             key = (edge.src, edge.dst)
-            if key in merged:
-                existing = merged[key]
-                merged[key] = PyCallEdge(
-                    source=existing.source,
-                    target=existing.target,
-                    weight=existing.weight + edge.weight,
-                    prov=existing.prov,
-                )
+            current = merged.get(key)
+            if current is None:
+                merged[key] = edge.model_copy()
             else:
-                merged[key] = edge
+                current.weight += edge.weight
+                current.prov = sorted(set(current.prov) | set(edge.prov))
         return list(merged.values())
 
     # ------------------------------------------------------------------

--- a/test/test_pycg_coalesce_edges.py
+++ b/test/test_pycg_coalesce_edges.py
@@ -1,0 +1,45 @@
+"""`_coalesce_edges` sums duplicate shard edges instead of raising (#133).
+
+It built the merged edge with `source=`/`target=` and read `existing.source`,
+but `PyCallEdge` declares `src`/`dst` with no aliases — so the duplicate branch,
+the only branch that does any work, raised `AttributeError`. Latent because it
+fires only when two shards report the same pair, which is the path large
+projects take.
+"""
+from codeanalyzer.schema.py_schema import PyCallEdge
+from codeanalyzer.semantic_analysis.pycg.pycg_analysis import PyCG
+
+
+def test_duplicate_pair_sums_weight_instead_of_raising():
+    edges = [
+        PyCallEdge(src="a.f", dst="b.g", weight=3, prov=["pycg"]),
+        PyCallEdge(src="a.f", dst="b.g", weight=2, prov=["pycg"]),
+    ]
+    (merged,) = PyCG._coalesce_edges(edges)
+    assert (merged.src, merged.dst) == ("a.f", "b.g")
+    assert merged.weight == 5
+
+
+def test_distinct_pairs_are_left_alone():
+    edges = [
+        PyCallEdge(src="a.f", dst="b.g", weight=1, prov=["pycg"]),
+        PyCallEdge(src="a.f", dst="c.h", weight=1, prov=["pycg"]),
+    ]
+    out = PyCG._coalesce_edges(edges)
+    assert {(e.src, e.dst) for e in out} == {("a.f", "b.g"), ("a.f", "c.h")}
+
+
+def test_provenance_unions_matching_merge_edges():
+    """`call_graph.merge_edges` unions prov; this must not silently differ."""
+    edges = [
+        PyCallEdge(src="a.f", dst="b.g", weight=1, prov=["pycg"]),
+        PyCallEdge(src="a.f", dst="b.g", weight=1, prov=["jedi"]),
+    ]
+    (merged,) = PyCG._coalesce_edges(edges)
+    assert merged.prov == ["jedi", "pycg"]
+
+
+def test_inputs_are_not_mutated():
+    first = PyCallEdge(src="a.f", dst="b.g", weight=1, prov=["pycg"])
+    PyCG._coalesce_edges([first, PyCallEdge(src="a.f", dst="b.g", weight=4, prov=["pycg"])])
+    assert first.weight == 1


### PR DESCRIPTION
Closes #133.

## Problem

`PyCG._coalesce_edges` built the merged edge with the wrong field names:

```python
merged[key] = PyCallEdge(
    source=existing.source,      # PyCallEdge declares src/dst, no aliases
    target=existing.target,
    ...
)
```

`existing.source` raises first, so the failure is `AttributeError: 'PyCallEdge' object has no attribute 'source'`. Verified directly.

It is latent because the broken code sits behind the duplicate branch — the only branch that does any work:

```python
if key in merged:   # <- broken
    ...
else:
    merged[key] = edge   # <- common path, fine
```

So it fires only when two shards report the same `(src, dst)` pair. That is reachable at `pycg_analysis.py:710`, on the sharded analysis path, which is the path large projects take.

## Change

Construct with `src=`/`dst=`, and mutate a copy rather than the caller's edge.

**Also answers the provenance question the issue raised.** `_coalesce_edges` kept `existing.prov` while `call_graph.merge_edges` unions it. Not observable today — every edge reaching this function carries `prov=["pycg"]` — but two functions that coalesce the same edges must not coalesce them differently, so this now unions to match. Made deliberate rather than left as an accidental divergence.

## Verification

Four tests in `test/test_pycg_coalesce_edges.py`: a duplicate pair sums weight instead of raising; distinct pairs are left alone; provenance unions the way `merge_edges` does; and inputs are not mutated. The first, third and fourth fail before this change.

`12 passed` across the three pycg test files.

## Caveat

The issue asked whether a `try/except` upstream had been hiding this. I did not find one — the function simply had not been reached with a duplicate in any tested project. Sharded runs will now coalesce where they previously would have crashed, so edge counts drop and weights rise where duplicates existed. That is the intended behaviour, not a regression.