### PR TITLE
fix(dataflow): recognise staticmethod by identity, not spelling

### DIFF
--- a/codeanalyzer/dataflow/access_paths.py
+++ b/codeanalyzer/dataflow/access_paths.py
@@ -245,15 +245,37 @@ def _names_loaded(node: ast.AST) -> Set[str]:
     return out
 
 
-def build_scope(func: ast.AST, enclosing_locals: Set[str]) -> FunctionScope:
+#: Jedi resolves every spelling of the builtin -- ``@staticmethod``,
+#: ``@builtins.staticmethod``, ``from builtins import staticmethod as sm`` --
+#: to this one name (#135).
+_STATICMETHOD_QUALIFIED = "builtins.staticmethod"
+
+
+def build_scope(
+    func: ast.AST,
+    enclosing_locals: Set[str],
+    decorator_names: Optional[Set[str]] = None,
+) -> FunctionScope:
     """Classify every base name the callable touches. ``enclosing_locals`` is
     the union of locals/params of all enclosing callables (for capture vs
-    global disambiguation)."""
+    global disambiguation).
+
+    ``decorator_names`` are the callable's Jedi-resolved decorator
+    ``qualified_name``s. When supplied, staticmethod detection is by identity,
+    so a dotted or aliased spelling is recognised (#135). When omitted -- a
+    caller with no resolved records -- it falls back to matching the written
+    source, which only recognises the bare ``@staticmethod``.
+    """
     params = _param_names(func)
     scope = FunctionScope(params=params)
     if params and isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
-        decorators = {ast.unparse(d) for d in func.decorator_list}
-        if params[0] in ("self", "cls") and "staticmethod" not in decorators:
+        if decorator_names is None:
+            is_static = "staticmethod" in {
+                ast.unparse(d) for d in func.decorator_list
+            }
+        else:
+            is_static = _STATICMETHOD_QUALIFIED in decorator_names
+        if params[0] in ("self", "cls") and not is_static:
             scope.self_name = params[0]
     scope.globals_ = _declared(func, ast.Global)
     nonlocals = _declared(func, ast.Nonlocal)

--- a/codeanalyzer/dataflow/builder.py
+++ b/codeanalyzer/dataflow/builder.py
@@ -186,6 +186,13 @@ def build_function_pdgs(
                 oracle=oracle,
                 k=k,
                 global_qualifier=module.module_name,
+                # Resolved decorator names, so staticmethod detection works for a
+                # dotted or aliased spelling and not just bare `@staticmethod` (#135).
+                decorator_names={
+                    d.qualified_name
+                    for d in (pycallable.decorators or [])
+                    if d.qualified_name
+                },
             )
             infos[pycallable.signature] = FunctionInfo(
                 signature=pycallable.signature, pdg=pdg, oracle=oracle

--- a/codeanalyzer/dataflow/pdg.py
+++ b/codeanalyzer/dataflow/pdg.py
@@ -66,10 +66,15 @@ def build_pdg(
     oracle: TypeBasedAliasOracle,
     k: int = 3,
     global_qualifier: Optional[str] = None,
+    decorator_names: Optional[Set[str]] = None,
 ) -> FunctionPDG:
-    """CFG → dominance → def-use → PDG for one callable."""
+    """CFG → dominance → def-use → PDG for one callable.
+
+    ``decorator_names`` are the callable's resolved decorator qualified names,
+    used for staticmethod detection by identity rather than spelling (#135).
+    """
     cfg = build_cfg(func)
-    scope = build_scope(func, enclosing_locals)
+    scope = build_scope(func, enclosing_locals, decorator_names=decorator_names)
     facts = statement_facts(cfg, func, scope, k, global_qualifier)
 
     edges: List[PDGEdge] = [

--- a/test/test_access_paths_receiver_binding.py
+++ b/test/test_access_paths_receiver_binding.py
@@ -1,0 +1,67 @@
+"""Receiver binding recognises staticmethod by identity, not spelling (#135).
+
+`build_scope` decided whether a callable has a receiver with
+`"staticmethod" not in {ast.unparse(d) for d in decorator_list}` — exact string
+membership against written source. `@builtins.staticmethod`, or an aliased
+import, failed that test, so a static method got a receiver it does not have and
+`scope.self_name` was later added as a definition, producing a spurious def in
+the L3/L4 dataflow.
+
+#128 gives every decorator a Jedi-resolved `qualified_name`, so the check can be
+made on identity: both `@staticmethod` and `@builtins.staticmethod` resolve to
+`builtins.staticmethod`.
+"""
+import ast
+
+from codeanalyzer.dataflow.access_paths import build_scope
+
+SRC = """\
+import builtins
+from builtins import staticmethod as sm
+
+
+class C:
+    @builtins.staticmethod
+    def dotted(self, x):
+        return x
+
+    @sm
+    def aliased(self, x):
+        return x
+
+    @staticmethod
+    def plain(self, x):
+        return x
+
+    def method(self, x):
+        return x
+"""
+
+_BY_NAME = {n.name: n for n in ast.parse(SRC).body[2].body}
+_RESOLVED = "builtins.staticmethod"
+
+
+def test_dotted_spelling_has_no_receiver():
+    scope = build_scope(_BY_NAME["dotted"], set(), decorator_names={_RESOLVED})
+    assert scope.self_name is None
+
+
+def test_aliased_import_has_no_receiver():
+    scope = build_scope(_BY_NAME["aliased"], set(), decorator_names={_RESOLVED})
+    assert scope.self_name is None
+
+
+def test_bare_spelling_still_has_no_receiver():
+    scope = build_scope(_BY_NAME["plain"], set(), decorator_names={_RESOLVED})
+    assert scope.self_name is None
+
+
+def test_an_ordinary_method_keeps_its_receiver():
+    scope = build_scope(_BY_NAME["method"], set(), decorator_names=set())
+    assert scope.self_name == "self"
+
+
+def test_unresolved_decorators_fall_back_to_the_written_spelling():
+    """Callers that cannot supply resolved names keep the old behaviour."""
+    assert build_scope(_BY_NAME["plain"], set()).self_name is None
+    assert build_scope(_BY_NAME["method"], set()).self_name == "self"


### PR DESCRIPTION
Closes #135.

## Problem

`build_scope` decided whether a callable has a receiver by exact string membership against unparsed source (`dataflow/access_paths.py:255`):

```python
decorators = {ast.unparse(d) for d in func.decorator_list}
if params[0] in ("self", "cls") and "staticmethod" not in decorators:
    scope.self_name = params[0]
```

Only the bare spelling matches. `@builtins.staticmethod` — or `from builtins import staticmethod as sm` — falls through, so a static method gets a receiver it does not have, and `scope.self_name` is later added as a definition (`access_paths.py:472-473`), putting a spurious def into the L3/L4 dataflow.

## Change

#128 made this cheap: every decorator now carries a Jedi-resolved `qualified_name`, and **every** spelling of the builtin resolves to the same one:

```
@builtins.staticmethod   name='builtins.staticmethod'   qualified_name='builtins.staticmethod'
@staticmethod            name='staticmethod'            qualified_name='builtins.staticmethod'
```

So `build_scope` takes an optional `decorator_names` set and checks identity. `build_pdg` passes it through; `dataflow/builder.py` supplies it from the `PyCallable` it already holds.

Measured on real symbol-table records, before and after:

```
dotted   resolved={'builtins.staticmethod'}   self_name  fixed=None    old='self'   <- fixed
method   resolved=set()                       self_name  fixed='self'  old='self'   <- unchanged
```

## Design note

`decorator_names` is **optional**, and the written-spelling match remains as the fallback. A caller with no resolved records keeps its current behaviour rather than being forced to thread records through — and the pipeline caller does supply them, which is where the defect actually bit. That keeps the blast radius to the one path that matters.

## Verification

Five tests in `test/test_access_paths_receiver_binding.py` covering the dotted spelling, an aliased import, the bare spelling, an ordinary method retaining its receiver, and the fallback path when no resolved names are supplied. Four fail before this change.

`18 passed` across the receiver-binding, PDG and def-use test files.

## Caveat

The trigger is narrow: the first parameter must be named `self` or `cls`, which is legal but unusual on a staticmethod. That is why no bug report prompted this — it was found by reading the code during #128's review, not from a failure in the wild.