### PR TITLE
fix(call-graph): keep module-scope calls to library targets

### DIFF
--- a/codeanalyzer/semantic_analysis/call_graph.py
+++ b/codeanalyzer/semantic_analysis/call_graph.py
@@ -254,9 +254,19 @@ def filter_external_edges(
     walking every callable in the symbol table recursively (including nested
     functions and closures via ``callables``) plus every class, so
     PyCG-discovered closure nodes are correctly recognised as app symbols.
+
+    Module names count as app symbols too (#131). PyCG attributes a call made in
+    module scope to the MODULE -- ``app -> functools.reduce`` for a module-level
+    ``functools.reduce(...)``, or for a decorator applied to a top-level
+    definition, since a decorator executes in its enclosing scope. Without the
+    module names here, both endpoints looked third-party and every module-scope
+    call to a library target was discarded as lib→lib.
     """
     app_symbols: set = {c.signature for c in iter_callables_in_symbol_table(symbol_table)}
     app_symbols.update(cls.signature for cls in iter_classes_in_symbol_table(symbol_table))
+    app_symbols.update(
+        mod.module_name for mod in symbol_table.values() if mod.module_name
+    )
 
     return [
         e for e in edges

--- a/test/test_call_graph_module_scope_edges.py
+++ b/test/test_call_graph_module_scope_edges.py
@@ -1,0 +1,68 @@
+"""Module-scope calls to library targets are not dropped as lib->lib (#131).
+
+`filter_external_edges` keeps an edge when either endpoint is an app symbol, but
+it built `app_symbols` from callables and classes only. PyCG attributes a call in
+module scope to the MODULE (`app -> functools.reduce`), and a module name was in
+neither set — so every module-level call to a library target was discarded as if
+both ends were third-party.
+
+Surfaced as "decorators with arguments are dropped", but decorators are only how
+it was noticed: a plain `TOTAL = functools.reduce(...)` at module scope was lost
+the same way.
+"""
+from codeanalyzer.schema.py_schema import PyCallable, PyCallEdge, PyModule
+from codeanalyzer.semantic_analysis.call_graph import filter_external_edges
+
+
+def _symbol_table() -> dict:
+    fn = PyCallable(name="in_a_function", path="app.py", signature="app.in_a_function")
+    return {
+        "app.py": PyModule(
+            file_path="app.py",
+            module_name="app",
+            functions={"in_a_function": fn},
+        )
+    }
+
+
+def test_module_scope_call_to_a_library_target_is_kept():
+    st = _symbol_table()
+    edges = [PyCallEdge(src="app", dst="functools.reduce", weight=1, prov=["pycg"])]
+    assert filter_external_edges(edges, st) == edges
+
+
+def test_module_scope_decorator_application_is_kept():
+    """The symptom in the issue title: a decorator applied at module scope."""
+    st = _symbol_table()
+    edges = [
+        PyCallEdge(src="app", dst="functools.lru_cache", weight=1, prov=["pycg"]),
+        PyCallEdge(src="app", dst="functools.cache", weight=1, prov=["pycg"]),
+    ]
+    assert filter_external_edges(edges, st) == edges
+
+
+def test_a_genuine_library_to_library_edge_is_still_dropped():
+    """The filter's actual purpose must survive the fix."""
+    st = _symbol_table()
+    edges = [PyCallEdge(src="os.path.join", dst="os.sep", weight=1, prov=["pycg"])]
+    assert filter_external_edges(edges, st) == []
+
+
+def test_callable_endpoints_are_unaffected():
+    st = _symbol_table()
+    edges = [
+        PyCallEdge(src="app.in_a_function", dst="functools.reduce", weight=1, prov=["jedi"]),
+        PyCallEdge(src="app", dst="app.in_a_function", weight=1, prov=["pycg"]),
+    ]
+    assert filter_external_edges(edges, st) == edges
+
+
+def test_a_module_named_like_a_library_is_still_an_app_symbol():
+    """Module names come from the analyzed symbol table, so shadowing is fine."""
+    st = {
+        "functools.py": PyModule(
+            file_path="functools.py", module_name="functools", functions={}
+        )
+    }
+    edges = [PyCallEdge(src="functools", dst="os.getcwd", weight=1, prov=["pycg"])]
+    assert filter_external_edges(edges, st) == edges


### PR DESCRIPTION
Closes #131.

## The reported symptom was misleading

Filed as *"PyCG drops the call edge for decorators with arguments (`functools.lru_cache`)"*. PyCG drops nothing — its raw output contains both edges:

```
app -> functools.cache
app -> functools.lru_cache
```

They are discarded downstream, by us.

## Root cause

`filter_external_edges` (`semantic_analysis/call_graph.py`) keeps an edge when either endpoint is an app symbol, but built `app_symbols` from **callables and classes only** — never modules. PyCG attributes a call made in module scope to the MODULE, so `app -> functools.reduce` has a module name on one end and a library on the other, matches neither set, and is dropped as though both ends were third-party.

## Two ways the title was wrong

**Not about arguments.** A matrix over scope × called-or-bare × first-party-or-stdlib:

| decorator | scope | target | edge? |
|---|---|---|---|
| `@local_bare` | module | first-party | ✅ |
| `@local_factory("x")` | module | first-party | ✅ |
| `@functools.cache` | module | stdlib | ❌ |
| `@functools.lru_cache(maxsize=128)` | module | stdlib | ❌ |
| `@functools.wraps(outer)` | inside a function | stdlib | ✅ |

`@functools.cache` takes no arguments and fails; `@local_factory("x")` takes one and works. The discriminator is module scope plus an external target.

**Not about decorators either.** A plain module-level call is lost identically:

```python
TOTAL = functools.reduce(lambda a, b: a + b, [1, 2, 3])   # no edge
def in_a_function():
    return functools.reduce(lambda a, b: a + b, [4, 5])   # edge
```

So **every module-level call into stdlib or a dependency was missing from the call graph of every analyzed project**. Decorators were only how it got noticed — which is why the issue asked for a root cause rather than a patch to the decorator path.

## Change

Module names join `app_symbols`. One statement.

They come from the analyzed symbol table rather than a denylist, so a first-party module shadowing a library name (a project with its own `functools.py`) is still correctly an app symbol — covered by a test. The filter's actual purpose is unchanged: a genuine library-to-library edge is still dropped, also tested.

## Verification

Both diagnostic fixtures, end to end after the fix:

```
d131    app -> cache ['pycg']            <- the reported symptom
        app -> lru_cache ['pycg']
d131b   app -> reduce ['pycg']           <- the non-decorator case
        in_a_function() -> reduce ['jedi','pycg']
```

Five tests in `test/test_call_graph_module_scope_edges.py`; three fail before the change.

`270 passed, 2 skipped, 4 deselected`.

## Caveat

**Edge counts rise.** Any project with module-scope calls into stdlib or a dependency gains edges it should always have had. No test asserted an exact count, so nothing broke — but a downstream consumer comparing graphs across versions will see growth, and the new numbers are the correct ones.