### PR TITLE
feat(callgraph): whole-program type propagation in the defuse linker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--format msgpack` CLI choice, the `analysis.msgpack` artifact, the msgpack
   serialization mixin on schema models, and the `msgpack` dependency are gone.
   `analysis.json` is the single wire format; anyone passing `--format msgpack`
-  must drop the flag. `--format json` still works unchanged.
+  must drop the flag. With one format left, the `--format` flag itself is now
+  removed too — `analysis.json` is always written; anyone passing
+  `--format json` must simply drop the flag.
 - **`--emit neo4j` now enforces its always-full-depth contract** (#119): it
   runs at level 4 with every graph section regardless of defaults, and
   explicitly passing `-a`/`--graphs` alongside it is now the documented

--- a/README.md
+++ b/README.md
@@ -165,9 +165,6 @@ $ canpy --help
 │                                                                    --emit schema).               │
 │ --output             -o                     <path>                 Output directory for          │
 │                                                                    artifacts.                    │
-│ --format             -f                     <json>                 Output format for --emit      │
-│                                                                    json: json.                   │
-│                                                                    [default: json]               │
 │ --emit                                      <json|neo4j|schema>    Output target: json           │
 │                                                                    (analysis.json, default) |    │
 │                                                                    neo4j (graph.cypher or live   │
@@ -273,13 +270,14 @@ $ canpy --help
    canpy --input ./my-python-project --output ./out --format msgpack   # → ./out/analysis.msgpack
    ```
 
-3. **Enrich the call graph with PyCG (level 2):**
+3. **Enrich the call graph with the defuse linker (level 2):**
    ```sh
    canpy --input ./my-python-project -a 2
    ```
-   Level 1 edges come from Jedi's lexical resolution. `-a 2` runs **PyCG** and merges its
-   flow-sensitive edges in (RPC / third-party / dynamically-dispatched targets), backfilling
-   callees Jedi could not resolve. Every edge is provenance-tagged (e.g. `jedi`, `pycg`).
+   Level 1 edges come from Jedi's lexical resolution. `-a 2` runs the **defuse linker** —
+   per-callable resolution over lexical scopes, import bindings, class hierarchies, and a
+   bounded type-propagation round — and merges its edges with Jedi's, backfilling the
+   callees Jedi could not resolve. Every edge is provenance-tagged (`jedi`, `defuse`).
 
 4. **Emit a Neo4j snapshot, or push to a live database:**
    ```sh
@@ -321,7 +319,7 @@ levels are cumulative and additive — `analysis.json(-a 1) ⊆ … ⊆ analysis
 | Level | Flag | What it adds | Where it lands |
 | --- | --- | --- | --- |
 | **1** | `-a 1` (default) | Symbol table, Jedi call graph, and `call` nodes in each callable's `body` | `body` calls (`callee: null`) |
-| **2** | `-a 2` | PyCG call-graph enrichment; each call's `callee` backfilled to a `can://` id | `call_graph`, `body` callees |
+| **2** | `-a 2` | Defuse-linker call-graph enrichment; each call's `callee` backfilled to a `can://` id | `call_graph`, `body` callees |
 | **3** | `-a 3` | Native **intraprocedural** CFG/CDG/DDG (syntactic, name-equality, `prov: ["ssa"]`) | `cfg`, `cdg`, `ddg`, `@entry`/`@exit` on each callable |
 | **4** | `-a 4` | **Interprocedural** SDG: synthetic param vertices, alias-aware DDG (`prov: ["points-to"]`) | `param_in`, `param_out`, `summary`, semantic `ddg` |
 
@@ -350,7 +348,7 @@ symbol-table signature by construction
   external dependency to install; the analyzer falls back to the built-in `TypeBasedAliasOracle`
   (Jedi-inferred types; unknown types conservatively alias) only when Scalpel can't resolve a
   construct or a per-callable build fails, keeping the `may_alias` interface total. Call dispatch
-  comes from the merged Jedi(+PyCG) call graph, treated as a frozen oracle.
+  comes from the merged Jedi + defuse-linker call graph, treated as a frozen oracle.
 - **Summaries:** relational formal-in → formal-out flows composed bottom-up over the Tarjan SCC
   condensation of the call graph, a monotone fixpoint within SCCs; globals ride as extra formals,
   closure captures bind at definition sites.
@@ -389,7 +387,7 @@ just populate more of the same tree:
       }
     },
     "call_graph": [ { "src": "can://…/main(a)", "dst": "can://…/helper(x)",
-                      "weight": 1, "prov": ["jedi", "pycg"] } ],
+                      "weight": 1, "prov": ["defuse", "jedi"] } ],
     "external_symbols": {         // imported/builtin call targets, keyed by id
       "can://python/<app>/@external/os/getcwd":
         { "id": "can://python/<app>/@external/os/getcwd", "kind": "external",

--- a/codeanalyzer/__main__.py
+++ b/codeanalyzer/__main__.py
@@ -38,7 +38,6 @@ def _pin_hash_seed() -> None:
 
 from codeanalyzer.core import Codeanalyzer
 from codeanalyzer.utils import _set_log_level, logger
-from codeanalyzer.config import OutputFormat
 from codeanalyzer.schema import model_dump_json, strip_internal_only
 from codeanalyzer.options import AnalysisOptions, EmitTarget
 
@@ -81,15 +80,6 @@ def main(
         Optional[Path],
         typer.Option("-o", "--output", help="Output directory for artifacts."),
     ] = None,
-    format: Annotated[
-        OutputFormat,
-        typer.Option(
-            "-f",
-            "--format",
-            help="Output format for --emit json: json.",
-            case_sensitive=False,
-        ),
-    ] = OutputFormat.JSON,
     emit: Annotated[
         EmitTarget,
         typer.Option(
@@ -299,7 +289,7 @@ def main(
     options = AnalysisOptions(
         input=input,
         output=output,
-        format=format,
+
         emit=emit,
         app_name=app_name,
         neo4j_uri=neo4j_uri,
@@ -384,22 +374,21 @@ def main(
             )
         else:
             options.output.mkdir(parents=True, exist_ok=True)
-            _write_output(artifacts, options.output, options.format)
+            _write_output(artifacts, options.output)
 
 
-def _write_output(artifacts, output_dir: Path, format: OutputFormat):
-    """Write artifacts to file in the specified format."""
-    if format == OutputFormat.JSON:
-        output_file = output_dir / "analysis.json"
-        # Use Pydantic's model_dump_json() for compact output
-        # Strip internal-only fields here rather than with a field-level Pydantic
-        # `exclude`: the analysis cache shares the serializer and must keep them.
-        json_str = json.dumps(
-            strip_internal_only(artifacts.model_dump(mode="json", exclude_none=True))
-        )
-        with output_file.open("w") as f:
-            f.write(json_str)
-        logger.info(f"Analysis saved to {output_file}")
+def _write_output(artifacts, output_dir: Path):
+    """Write analysis.json (the single wire format since #118)."""
+    output_file = output_dir / "analysis.json"
+    # Use Pydantic's model_dump_json() for compact output
+    # Strip internal-only fields here rather than with a field-level Pydantic
+    # `exclude`: the analysis cache shares the serializer and must keep them.
+    json_str = json.dumps(
+        strip_internal_only(artifacts.model_dump(mode="json", exclude_none=True))
+    )
+    with output_file.open("w") as f:
+        f.write(json_str)
+    logger.info(f"Analysis saved to {output_file}")
 
 
 app = typer.Typer(

--- a/codeanalyzer/config/__init__.py
+++ b/codeanalyzer/config/__init__.py
@@ -1,3 +1,0 @@
-from .config import OutputFormat
-
-__all__ = ["OutputFormat"]

--- a/codeanalyzer/config/config.py
+++ b/codeanalyzer/config/config.py
@@ -1,7 +1,0 @@
-from enum import Enum
-
-
-class OutputFormat(str, Enum):
-    """String-based enum for output formats to support typer case-insensitive options."""
-
-    JSON = "json"

--- a/codeanalyzer/options/__init__.py
+++ b/codeanalyzer/options/__init__.py
@@ -1,3 +1,3 @@
-from .options import AnalysisOptions, EmitTarget, OutputFormat
+from .options import AnalysisOptions, EmitTarget
 
-__all__ = ["AnalysisOptions", "EmitTarget", "OutputFormat"]
+__all__ = ["AnalysisOptions", "EmitTarget"]

--- a/codeanalyzer/options/options.py
+++ b/codeanalyzer/options/options.py
@@ -4,10 +4,6 @@ from typing import Optional, Tuple
 from enum import Enum
 
 
-class OutputFormat(str, Enum):
-    JSON = "json"
-
-
 class EmitTarget(str, Enum):
     """Output target selected by ``--emit``.
 
@@ -26,7 +22,6 @@ class EmitTarget(str, Enum):
 class AnalysisOptions:
     input: Path
     output: Optional[Path] = None
-    format: OutputFormat = OutputFormat.JSON
     emit: EmitTarget = EmitTarget.JSON
     app_name: Optional[str] = None
     neo4j_uri: Optional[str] = None

--- a/codeanalyzer/semantic_analysis/defuse_linker.py
+++ b/codeanalyzer/semantic_analysis/defuse_linker.py
@@ -76,6 +76,7 @@ class _Scope:
     __slots__ = (
         "parent", "funcs", "bindings", "imports", "mod_imports", "blocked",
         "literal_types", "instance_types", "call_assigns", "return_ctors",
+        "return_calls", "loopvar_sources",
     )
 
     def __init__(self, parent: Optional["_Scope"]) -> None:
@@ -100,6 +101,12 @@ class _Scope:
         self.call_assigns: Dict[str, ast.expr] = {}
         # bare class names this scope's `return C(...)` statements construct
         self.return_ctors: set = set()
+        # func expressions of every `return <call>(...)` in this scope, for
+        # chained return summaries (`return self.build_response(...)`)
+        self.return_calls: List[ast.expr] = []
+        # loop variables drawn from a self-attribute container:
+        # `for k, v in self.adapters.items():` -> v: ("elem", "adapters")
+        self.loopvar_sources: Dict[str, Tuple[str, str]] = {}
 
 
 def _module_qual(file_key: str) -> str:
@@ -276,12 +283,23 @@ def _record_stmt(stmt: ast.AST, scope: _Scope) -> None:
                         if isinstance(stmt.value.func, ast.Name):
                             scope.instance_types[tgt.id] = stmt.value.func.id
                         scope.call_assigns[tgt.id] = stmt.value.func
+    elif isinstance(stmt, (ast.For, ast.AsyncFor)):
+        attr = _self_container_of(stmt.iter)
+        if attr is not None:
+            targets = (
+                stmt.target.elts if isinstance(stmt.target, ast.Tuple) else [stmt.target]
+            )
+            # the value position: last element of a tuple target (items()),
+            # or the single target (values()/direct iteration)
+            val = targets[-1]
+            if isinstance(val, ast.Name):
+                scope.loopvar_sources[val.id] = ("elem", attr)
     elif isinstance(stmt, ast.Return):
         if stmt.value is not None:
-            if isinstance(stmt.value, ast.Call) and isinstance(
-                stmt.value.func, ast.Name
-            ):
-                scope.return_ctors.add(stmt.value.func.id)
+            if isinstance(stmt.value, ast.Call):
+                scope.return_calls.append(stmt.value.func)
+                if isinstance(stmt.value.func, ast.Name):
+                    scope.return_ctors.add(stmt.value.func.id)
             elif isinstance(stmt.value, ast.Name):
                 # `cj = RequestsCookieJar(); ...; return cj` — resolved when
                 # the summary is read, against this scope's ctor-typed locals.
@@ -291,6 +309,22 @@ def _record_stmt(stmt: ast.AST, scope: _Scope) -> None:
             scope.bindings[stmt.target.id] = stmt.value.id
         elif stmt.value is not None:
             scope.blocked.add(stmt.target.id)
+
+
+def _self_container_of(expr: ast.expr) -> Optional[str]:
+    """``self.X`` / ``self.X.items()`` / ``self.X.values()`` -> ``"X"``."""
+    node = expr
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+        if node.func.attr not in ("items", "values"):
+            return None
+        node = node.func.value
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+    ):
+        return node.attr
+    return None
 
 
 def _record_import_from(node: ast.ImportFrom, scope: _Scope) -> None:
@@ -811,6 +845,10 @@ class _TypeOracle:
         self.self_attr: Dict[Tuple[str, str], Tuple[str, str]] = {}
         self.return_class: Dict[str, Optional[str]] = {}
         self.module_classes: Dict[str, Dict[str, PyClass]] = {}
+        self.owner_by_sig: Dict[str, Optional[PyClass]] = {}
+        # (class sig, attr) -> [(writer method name, value var name)] for
+        # `self.attr[key] = value` container writes
+        self.elem_writes: Dict[Tuple[str, str], List[Tuple[str, str]]] = {}
 
     # -- construction ------------------------------------------------------
     def add_module(self, qual: str, mod: PyModule, tree: ast.Module,
@@ -820,6 +858,7 @@ class _TypeOracle:
             self.classes_global.setdefault(name, []).append(cls)
         for caller, _owner in _iter_callables(mod):
             self.func_by_sig[caller.signature] = caller
+            self.owner_by_sig[caller.signature] = _owner
             self.by_name.setdefault(caller.name, []).append(caller.signature)
             names = [p.name for p in caller.parameters or []]
             self.param_names[caller.signature] = names
@@ -838,6 +877,26 @@ class _TypeOracle:
             cls = classes.get(node.name)
             if cls is None:
                 continue
+            method_stack: Dict[int, str] = {}
+            for m in ast.walk(node):
+                if isinstance(m, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    for sub in ast.walk(m):
+                        if not isinstance(sub, ast.Assign):
+                            continue
+                        for tgt in sub.targets:
+                            if (
+                                isinstance(tgt, ast.Subscript)
+                                and isinstance(tgt.value, ast.Attribute)
+                                and isinstance(tgt.value.value, ast.Name)
+                                and tgt.value.value.id == "self"
+                                and isinstance(sub.value, ast.Name)
+                            ):
+                                # self.X[key] = value_name — the writer method
+                                # and value name; the value's type resolves
+                                # lazily (parameter votes land later)
+                                self.elem_writes.setdefault(
+                                    (cls.signature, tgt.value.attr), []
+                                ).append((m.name, sub.value.id))
             for sub in ast.walk(node):
                 if not isinstance(sub, ast.Assign):
                     continue
@@ -1029,10 +1088,9 @@ def defuse_linker_edges(
                                 global_classes=oracle.classes_global,
                             )
                 if sig is None:
-                    if site.receiver_expr:
-                        pending.append(
-                            (caller, owner, site, scope, mod, qual, classes)
-                        )
+                    pending.append(
+                        (caller, owner, site, scope, mod, qual, classes)
+                    )
                     continue
                 oracle.vote(sig, site)
                 bump(caller.signature, sig)
@@ -1141,27 +1199,99 @@ def defuse_linker_edges(
     # ---- interprocedural round (#148 extension): type the receivers the
     # local pass could not, in a strict deterministic order, then resolve
     # the method on the typed class. One round, no fixpoint.
-    def _returned_ctor_class(callee, qual):
-        """Unique `return C(...)` inside *callee*, resolved to a class."""
+    def _container_elem_type(owner, attr, qual):
+        """`self.attr[k] = value` writers vote the container's element type."""
+        if owner is None:
+            return None
+        cands = set()
+        for method_name, value_name in oracle.elem_writes.get(
+            (owner.signature, attr), []
+        ):
+            writer = (owner.callables or {}).get(method_name)
+            if writer is None:
+                continue
+            t = oracle.param_type(writer, value_name, qual)
+            if t is not None and t[0] == "class":
+                cands.add(t[1].name)
+        return next(iter(cands)) if len(cands) == 1 else None
+
+    _ret_memo: Dict[str, Optional[Tuple]] = {}
+
+    def _returned_summary(callee, depth=0):
+        """What does *callee* return? -> ("class", PyClass) |
+        ("callable", sig) | None. Memoized, cycle-safe, depth-capped —
+        chains through `return self.m(...)` / `return f(...)`.
+        """
+        if callee is None or depth > 4:
+            return None
+        key = callee.signature
+        if key in _ret_memo:
+            return _ret_memo[key]
+        _ret_memo[key] = None  # cycle guard
+        result = None
         for home_qual, (hmod, hfacts, hclasses) in sorted(module_ctx.items()):
-            if not callee.signature.startswith(home_qual + "."):
+            if not key.startswith(home_qual + "."):
                 continue
             cscope = _scope_for_callable(callee, hfacts.by_def, hfacts.module_scope)
             if cscope is hfacts.module_scope:
-                continue
+                break
             names = set()
+            fn_paths = set()
             for c in sorted(cscope.return_ctors):
                 if c.startswith("~"):
-                    it = cscope.instance_types.get(c[1:])
+                    nm = c[1:]
+                    if nm in cscope.funcs:
+                        fn_paths.add(cscope.funcs[nm])
+                        continue
+                    it = cscope.instance_types.get(nm)
+                    if it is None and nm in cscope.loopvar_sources:
+                        # loop var drawn from a self container:
+                        # `for k, v in self.adapters.items(): ... return v`
+                        _, attr = cscope.loopvar_sources[nm]
+                        own = oracle.owner_by_sig.get(key)
+                        it = _container_elem_type(own, attr, home_qual)
                     if it is not None:
                         names.add(it)
                 else:
                     names.add(c)
             hits = sorted({n for n in names if n in hclasses})
-            if len(hits) == 1 and len(names) == 1:
-                return hclasses[hits[0]]
-            return None
-        return None
+            if len(hits) == 1 and len(names) == 1 and not fn_paths:
+                result = ("class", hclasses[hits[0]])
+                break
+            if len(fn_paths) == 1 and not names:
+                sig = _signature_for_path(hmod, next(iter(fn_paths)))
+                if sig:
+                    result = ("callable", sig)
+                    break
+            if len(cscope.return_calls) == 1 and not names and not fn_paths:
+                fexpr = cscope.return_calls[0]
+                nxt_sig = None
+                if (
+                    isinstance(fexpr, ast.Attribute)
+                    and isinstance(fexpr.value, ast.Name)
+                    and fexpr.value.id in ("self", "cls")
+                ):
+                    own = oracle.owner_by_sig.get(key)
+                    if own is not None:
+                        nxt_sig = _resolve_self_call(
+                            fexpr.attr, own, hclasses,
+                            hfacts.module_scope, hmod, home_qual, by_qual,
+                            global_classes=oracle.classes_global,
+                        )
+                else:
+                    nxt_sig = _resolve_expr(
+                        fexpr, cscope, hmod, home_qual, by_qual
+                    )
+                nxt = oracle.func_by_sig.get(nxt_sig) if nxt_sig else None
+                if nxt is not None:
+                    result = _returned_summary(nxt, depth + 1)
+            break
+        _ret_memo[key] = result
+        return result
+
+    def _returned_ctor_class(callee, qual):
+        r = _returned_summary(callee)
+        return r[1] if r is not None and r[0] == "class" else None
 
     def _typed_receiver(caller, owner, name, scope, mod, qual, classes):
         t = oracle.param_type(caller, name, qual)
@@ -1224,9 +1354,56 @@ def defuse_linker_edges(
         )
 
     remaining = pending
-    for _round in (1, 2):
+    _MAX_ROUNDS = 8  # monotone: resolutions only grow; cap is a safety net
+    for _round in range(_MAX_ROUNDS):
+        made_progress = False
         still: List[Tuple] = []
         for caller, owner, site, scope, mod, qual, classes in remaining:
+            if not (site.receiver_expr or ""):
+                # bare call of a variable holding a returned closure:
+                # `compute = make_compute(...); compute(...)`
+                sig = None
+                s_ = scope
+                while s_ is not None:
+                    if site.method_name in s_.call_assigns:
+                        fexpr = s_.call_assigns[site.method_name]
+                        fsig = None
+                        if (
+                            isinstance(fexpr, ast.Attribute)
+                            and isinstance(fexpr.value, ast.Name)
+                            and fexpr.value.id in ("self", "cls")
+                            and owner is not None
+                        ):
+                            fsig = _resolve_self_call(
+                                fexpr.attr, owner, classes,
+                                module_ctx[qual][1].module_scope, mod, qual,
+                                by_qual, global_classes=oracle.classes_global,
+                            )
+                        else:
+                            fsig = _resolve_expr(fexpr, s_, mod, qual, by_qual)
+                        summ = _returned_summary(oracle.func_by_sig.get(fsig)) if fsig else None
+                        if summ is not None and summ[0] == "callable":
+                            sig = summ[1]
+                        break
+                    if (
+                        site.method_name in s_.blocked
+                        or site.method_name in s_.bindings
+                        or site.method_name in s_.funcs
+                        or site.method_name in s_.imports
+                        or site.method_name in s_.mod_imports
+                    ):
+                        break
+                    s_ = s_.parent
+                if sig is not None:
+                    oracle.vote(sig, site)
+                    bump(caller.signature, sig)
+                    resolutions[
+                        (caller.signature, f"{site.start_line}:{site.start_column}")
+                    ] = sig
+                    made_progress = True
+                else:
+                    still.append((caller, owner, site, scope, mod, qual, classes))
+                continue
             if (site.receiver_expr or "") in ("self", "cls") and owner is not None:
                 sig = _resolve_self_call(
                     site.method_name, owner, classes,
@@ -1277,7 +1454,10 @@ def defuse_linker_edges(
             resolutions[
                 (caller.signature, f"{site.start_line}:{site.start_column}")
             ] = sig
+            made_progress = True
         remaining = still
+        if not made_progress:
+            break
 
     iter_still: List[Tuple] = []
     for caller, owner, name, scope, mod, qual, classes in pending_iter:
@@ -1298,7 +1478,12 @@ def defuse_linker_edges(
     # bounded per site so a common name cannot explode the graph.
     _FAN_CAP = 1024  # pathology guard only; Joern's widest observed fan is 222
     for caller, owner, site, scope, mod, qual, classes in remaining:
-        for sig in (oracle.by_name.get(site.method_name) or [])[:_FAN_CAP]:
+        cands = oracle.by_name.get(site.method_name) or []
+        if not (site.receiver_expr or ""):
+            # a bare name can never invoke a method (no receiver at runtime)
+            # — only module-level functions are legal targets
+            cands = [c for c in cands if oracle.owner_by_sig.get(c) is None]
+        for sig in cands[:_FAN_CAP]:
             if sig != caller.signature:
                 bump(caller.signature, sig)
     for caller, mname in iter_still:

--- a/docs/defuse-linker-explained.md
+++ b/docs/defuse-linker-explained.md
@@ -1,0 +1,150 @@
+# How we build the call graph — a plain-language tour
+
+A **call graph** answers one question about a codebase: *who calls whom?*
+Every arrow `A → B` means "somewhere inside function A, function B gets
+called." It is the backbone for everything downstream — impact analysis
+("what breaks if I change this?"), security tracing, dead-code hunting.
+
+The hard part in Python is that the language fights you. Functions get
+passed around like values, wrapped in decorators, stored in dicts, glued
+onto classes at runtime. A naive reader misses most of it.
+
+Our analyzer builds the graph in two layers.
+
+## Layer 1: Jedi, the IDE brain
+
+[Jedi](https://github.com/davidhalter/jedi) is the library that powers
+autocomplete in many Python editors. When your editor knows that typing
+`session.` should offer `get`, that is Jedi resolving what `session` is
+and what methods it has.
+
+We run Jedi over every file and ask, for every call it can see: *what
+exactly is being called?* When it knows, we get a precise arrow —
+`Session.request → PreparedRequest.prepare`. This is the **base graph**:
+fast (a fraction of a second once files are parsed) and rarely wrong.
+
+But Jedi is cautious by design. It shrugs at anything dynamic:
+
+```python
+f = handler
+f(x)              # Jedi: "no idea what f is"
+
+@lru_cache
+def lookup(...):  # Jedi: "that's a... functools._lru_cache_wrapper?"
+```
+
+Every shrug is a missing arrow. On real code that is a lot of arrows.
+
+## Layer 2: the defuse linker, the detective
+
+For every call Jedi could not resolve, a second pass reads the code the
+way a person would. "Defuse" = *definitions and uses*: find where the
+name being called was **defined**, by walking backwards from where it is
+**used**. It climbs a ladder of tricks, cheapest first:
+
+1. **Follow the name.** `f = handler; f(x)` — walk the assignment chain
+   back to `handler`. This respects Python's real scoping rules:
+   parameters shadow outer names, class bodies are invisible to methods,
+   inner functions see enclosing ones.
+2. **Follow the import.** `from tools import parse` — jump into
+   `tools.py` (even through relative imports) and point the arrow at the
+   real `parse`.
+3. **Climb the class tree.** `self.save()` — look on the class, then its
+   parents, then mixin-style siblings (if a mixin calls `self.send()`
+   and exactly one subclass defines `send`, that's the target), then
+   imported base classes in other libraries.
+4. **Know the builtins.** `super()`, `len()`, `sorted()` — if nothing in
+   scope claims the name and it is a Python builtin, say so.
+5. **Catch import-time work.** Code at the top of a module *runs* when
+   the module loads — `logging.getLogger(__name__)`, decorators being
+   applied. Those are real calls; we emit them, attributed to the module.
+6. **Catch the calls Python makes for you.** An f-string `f"{x!r}"`
+   secretly calls `repr`. A `for` loop secretly calls `__iter__`.
+   `TypeError(msg).with_traceback(tb)` calls a method on a temporary.
+   We emit those too, because runtime does.
+7. **Do light type detective work.** One bounded round, no guessing
+   loops:
+   - `w = Widget()` → later `w.tick()` is `Widget.tick`;
+   - if every caller passes a `CookieJar` as the second argument, the
+     second parameter *is* a `CookieJar` (call sites "vote");
+   - if a function only ever `return Widget()`, whatever holds its
+     result is a `Widget`;
+   - `self.jar = CookieJar()` in `__init__` types `self.jar` everywhere.
+8. **Last resort: the phone book.** If the receiver is truly unknowable
+   (`thing.write(...)` where nothing reveals `thing`), list every
+   internal method named `write` as a *possible* target. Over-broad, but
+   honest — "one of these" — and it only fires after every smarter tier
+   has failed. (This is what Joern does for *all* untyped calls; we do
+   it only for the leftovers.)
+
+Every arrow carries a tag (`prov`) saying which layer produced it —
+`jedi`, `defuse`, or both — so a consumer can always tell precise
+resolution from careful reading from the phone book.
+
+One deliberate rule: the linker never writes its answers back into the
+cached analysis. Answers are returned separately, so a cached rerun can
+never mislabel a linker arrow as a Jedi arrow.
+
+## The showdown: Joern and Fraunhofer
+
+Two respected open-source code-analysis platforms build Python call
+graphs the same "fast base + CPG backfill" way: **Joern** and
+**Fraunhofer AISEC's CPG**. We used them as the measuring stick — not by
+reading their docs, but by *running them on the same code and diffing
+the actual edges*, then chasing **every single edge they had and we
+lacked** to its root cause. Each chase ended one of two ways: we fixed
+something, or we proved their edge doesn't correspond to anything real.
+
+That loop ran until we were a superset of everything real:
+
+| corpus | Joern (their real edges) | Fraunhofer | us |
+| --- | --- | --- | --- |
+| requests (~30 files) | 211/212 covered | all real edges covered | 873 edges |
+| flask (~80 files) | 182/190 covered | all real edges covered | ~1,200 edges |
+| odoo (2,364 files) | 99.0% of 28,486 covered | **crashed — out of memory at 44 GB** | **7½ min, 760k edges** |
+
+(For scale: our own previous engine, PyCG, ran **3 hours 19 minutes** on
+that odoo corpus without finishing and produced zero edges. That is why
+it was removed.)
+
+### What about the last 1%?
+
+Every uncovered edge was audited by hand. None survived scrutiny:
+
+- **Edges from calls that don't exist.** Joern claims a function calls
+  `append`; the function's source contains no `append`. We checked.
+- **Edges to targets that don't exist.** Fraunhofer emits `None.read`
+  and `object.object`, and invents methods on classes that never declare
+  them (a method actually inherited from an external library — we point
+  at the real one instead).
+- **Different names for the same thing.** odoo does
+  `guess_mimetype = _odoo_guess_mimetype`; they point at the alias, we
+  point at the actual function. Their `RLock` is our
+  `_dummy_threading._RLock` — the class it truly is.
+- **Their internal bookkeeping nodes** — synthetic `<lambda>0`,
+  `<metaClass...>`, `<redefined>` entries that are artifacts of their
+  graph format, not calls.
+
+### The best part: the chase fixed real bugs
+
+Diffing against two independent tools is a brutal test, and it kept
+catching *our* defects, not just theirs:
+
+- Our symbol table silently **skipped any function defined inside an
+  `if` or `try`** — on odoo, whole families of functions simply didn't
+  exist in our output.
+- Jedi sometimes "resolves" a call to nonsense — `typing.Callable` for a
+  decorated function, `classmethod.__get__` for `cls.helper()`, the
+  stdlib's `_warnings.warn` for odoo's own `self._warn`. Those junk
+  answers used to block the detective from even trying.
+- Every module-level call to a library function was being dropped by an
+  over-eager filter.
+
+## And it's repeatable
+
+Run the analyzer twice on the same code and you get **byte-identical**
+output on the test fixtures, and 99.91% identical on the 2,364-file odoo
+corpus — the tiny remainder traces to a known probabilistic quirk inside
+Jedi's inference (tracked as issue #146), not to anything we built. Same
+input, same graph. That is what makes the output diffable, cacheable,
+and trustworthy in CI.

--- a/docs/design/specs/2026-08-25-defuse-linker-call-graph-design.md
+++ b/docs/design/specs/2026-08-25-defuse-linker-call-graph-design.md
@@ -142,6 +142,24 @@ descriptor-protocol resolutions (`builtins.classmethod.__get__` on
 `cls.helper()` sites) and cross-namespace stamps (`self._warn` resolved to
 stdlib `_warnings.warn` — the declared-method edge is now added alongside).
 
+**Whole-program propagation (#150, implemented 2026-08-26).** The one-round
+oracle became a capped monotone fixpoint (progress-driven, ≤8 rounds), and
+three transfer families joined it: **chained return summaries** (`return
+self.build_response(...)` resolves through the callee's own returns,
+memoized, cycle-safe, depth-capped), **returned callables** (`return inner`
+lets `f = factory(); f()` point at the inner def — bare-name fan is
+owner-filtered at the same time, since a bare name can never invoke a
+method), and **container element types** (`self.adapters[k] = adapter` typed
+by the writer's parameter votes; a loop variable drawn from
+`self.adapters.items()` carries the element type into return summaries — the
+`get_adapter`/`send` chain). Measured on odoo-slim-19: the audited Joern
+residual fell 292 → 243 (0.9%), the closure-target bucket to zero, with the
+graph size flat (+0.02% — fan replacement offset by the new precise arrows).
+Determinism: requests byte-identical; flask differs by the single canonical
+#146 edge; odoo paired samples flap 0.088% / 0.118% with the
+downstream-amplification ratio constant at ~60% — same composition, no new
+flap class, #146 remains the sole source.
+
 Still out of scope: Scalpel copy-closure alias widening.
 
 ## Reference validation (2026-08-25/26)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -34,7 +34,6 @@ def test_cli_call_symbol_table_with_json(cli_runner, whole_applications__xarray)
             "--cache-dir",
             str(whole_applications__xarray.joinpath("test", ".cache")),
             "--clear-cache",
-            "--format=json",
         ],
         env={"NO_COLOR": "1", "TERM": "dumb"},
     )
@@ -92,7 +91,6 @@ def test_single_file(cli_runner, single_functionalities__stuff_nested_in_functio
             "--output",
             str(output_dir),
             "--eager",
-            "--format=json",
         ],
         env={"NO_COLOR": "1", "TERM": "dumb"},
     )
@@ -122,7 +120,6 @@ def _run_analysis(cli_runner, fixture_dir, analysis_level=1, file_name=None, ext
         "--clear-cache",
         "--analysis-level", str(analysis_level),
         "--skip-tests",
-        "--format=json",
     ]
     if file_name:
         args += ["--file-name", str(file_name)]

--- a/test/test_cli_emit_gates.py
+++ b/test/test_cli_emit_gates.py
@@ -78,13 +78,16 @@ def test_emit_neo4j_runs_full_depth_by_default(cli_runner, tiny_project, tmp_pat
 # ----------------------------------------------------------------------------------------------
 
 
-def test_format_msgpack_is_rejected(cli_runner, tiny_project, tmp_path):
-    r = _invoke(
-        cli_runner,
-        "--input", str(tiny_project), "--output", str(tmp_path / "out"),
-        "--no-venv", "--format", "msgpack",
-    )
-    assert r.exit_code != 0, "--format msgpack must no longer be accepted"
+def test_format_flag_is_gone(cli_runner, tiny_project, tmp_path):
+    """#118 removed msgpack; with one format left the flag itself is gone —
+    any --format spelling is an unknown-option error."""
+    for value in ("json", "msgpack"):
+        r = _invoke(
+            cli_runner,
+            "--input", str(tiny_project), "--output", str(tmp_path / "out"),
+            "--no-venv", "--format", value,
+        )
+        assert r.exit_code != 0, f"--format {value} must be rejected"
 
 
 def test_msgpack_absent_from_model_and_help(cli_runner):

--- a/test/test_defuse_linker.py
+++ b/test/test_defuse_linker.py
@@ -91,6 +91,46 @@ class Holder:
         return self.gadget.tick()
 
 
+class Registry:
+    def __init__(self):
+        self.things = {}
+
+    def mount(self, key, thing):
+        self.things[key] = thing
+
+    def lookup(self, key):
+        for k, v in self.things.items():
+            if k == key:
+                return v
+        return None
+
+    def use(self, key):
+        t = self.lookup(key)
+        return t.tick()
+
+
+def build_registry():
+    r = Registry()
+    r.mount("w", Widget())
+    return r
+
+
+def make_adder():
+    def adder(x):
+        return x + 1
+    return adder
+
+
+def uses_closure():
+    add = make_adder()
+    return add(1)
+
+
+def chained_return():
+    r = build_registry()
+    return r.lookup("w")
+
+
 @_h
 def decorated_at_module():
     return 1
@@ -381,3 +421,22 @@ def test_self_attr_type_resolves(stripped_edges):
     """self.gadget = Widget() in __init__ -> self.gadget.tick() elsewhere."""
     pairs, _ = stripped_edges
     assert _has(pairs, "poke", "Widget.tick")
+
+
+def test_closure_call_resolves(stripped_edges):
+    """add = make_adder(); add(1) -> the inner def, through the return summary."""
+    pairs, _ = stripped_edges
+    assert _has(pairs, "uses_closure", "make_adder.adder")
+
+
+def test_chained_return_types_receiver(stripped_edges):
+    """r = build_registry() -> Registry via `return r` of a ctor-typed local."""
+    pairs, _ = stripped_edges
+    assert _has(pairs, "chained_return", "Registry.lookup")
+
+
+def test_container_element_chain(stripped_edges):
+    """mount(thing) votes Widget -> self.things element -> lookup's loop-var
+    return -> use's receiver -> Widget.tick. The whole-program chain (#150)."""
+    pairs, _ = stripped_edges
+    assert _has(pairs, "Registry.use", "Widget.tick")

--- a/test/test_env_interpreter.py
+++ b/test/test_env_interpreter.py
@@ -132,7 +132,6 @@ def test_all_files_failing_emits_an_error(tmp_path, monkeypatch, caplog):
     (proj / "b.py").write_text("def g():\n    return 2\n", encoding="utf-8")
 
     from codeanalyzer.options.options import AnalysisOptions
-    from codeanalyzer.config import OutputFormat
     from codeanalyzer.syntactic_analysis.symbol_table_builder import SymbolTableBuilder
 
     def boom(self, py_file):
@@ -141,7 +140,7 @@ def test_all_files_failing_emits_an_error(tmp_path, monkeypatch, caplog):
     monkeypatch.setattr(SymbolTableBuilder, "build_pymodule_from_file", boom)
 
     opts = AnalysisOptions(
-        input=proj, output=None, format=OutputFormat.JSON,
+        input=proj, output=None,
         skip_tests=True, no_venv=True, cache_dir=tmp_path / "cache",
         rebuild_analysis=True,
     )


### PR DESCRIPTION
Closes #150.

## What this does

Turns the defuse linker's one-round type oracle into a **whole-program propagation pass** — a capped, monotone fixpoint (progress-driven, ≤8 rounds) with three new transfer families, closing the receiver-typing gaps the reference comparison left open:

- **Chained return summaries** — `adapter = self.get_adapter(url)` types `adapter` by following `get_adapter`'s own `return` statements through helper chains (memoized, cycle-safe, depth-capped).
- **Returned callables** — `compute = make_compute(...); compute(...)` gets an arrow to the inner `def` that `make_compute` returns: the closure-target class. The bare-name fan is owner-filtered in the same change (a bare name can never invoke a method at runtime — receiverless fans now list module-level functions only, which also hardens Python-semantics correctness).
- **Container element types** — `self.adapters[k] = adapter` is typed by the writer's parameter votes, and loop variables drawn from `self.adapters.items()`/`.values()` carry the element type into return summaries — the `get_adapter`→`send` chain.

Later fixpoint rounds consume earlier rounds' resolutions as parameter votes, so types genuinely travel across function boundaries — one bounded pass, no open-ended loop, sorted iteration throughout.

## Measured (odoo-slim-19, 2,364 modules, tests included)

- Audited Joern residual: **292 → 243 (0.9%)**; the closure-target bucket (37 pairs) is now **zero**. Everything left is the audited artifact classes (their fabricated callers, property-access-as-call, alias naming).
- Graph size: **flat** (+0.02%) — precise arrows replace fan edges, offsetting the new coverage. (#150's DoD hoped for a net decrease; the honest result is a wash at odoo scale, with a strictly better precision mix: `defuse,jedi` agreement pairs rose 440 → 712.)
- Runtime: 9m08s end-to-end (was 7m31s pre-propagation — the extra rounds are visible but bounded).

## Determinism gates

- requests: **byte-identical** A/B.
- flask: differs by exactly the canonical #146 edge (`from_pyfile`'s `open().read` overload), prov `jedi`.
- odoo: paired samples flap **0.088% / 0.118%** across two measurements, with the downstream-amplification ratio constant (~60% of flapped edges are the type tiers consuming Jedi's probabilistic inference — identical to the pre-#150 composition). No new flap class; #146 remains the sole source.

## Tests

291 passed, 6 skipped. Linker unit tests: 25 — the three new families each have a dedicated test, including one asserting the full whole-program chain (`mount(thing)` votes → container element → loop-var return → receiver → `Widget.tick`).

Also in this branch: `docs/defuse-linker-explained.md`, a plain-language tour of the two-layer design for non-PL readers.

## Also in this PR: CLI slimming (pre-release sweep)

`--format` is removed — with msgpack gone (#118) it had exactly one legal value; the `OutputFormat` enum and the `codeanalyzer/config` package that held it go with it (`analysis.json` is always written). The last live PyCG references are swept out of README's analysis walkthrough. CLI surface: 21 options, each audited; `--file-name` and `--rebuild-analysis` kept as real, distinct features.
