### PR TITLE
feat: config_use edge — level-graded PY_USES_CONFIG with unresolved-read hygiene

### DIFF
--- a/.claude/SCHEMA_DECISIONS.md
+++ b/.claude/SCHEMA_DECISIONS.md
@@ -329,3 +329,60 @@ rels `HAS_ARTIFACT` (PyApplication→Artifact), `DECLARES_DEPENDENCY`
 - Always projected regardless of `-a` — this section is L1 data, identical at
   every analysis level (mirrors `analysis.json`), consistent with Neo4j's
   existing full-depth-always posture for `--emit neo4j`.
+
+## 2026-08-28 — Config family: neutral `ConfigKey` + `PY_USES_CONFIG`/`PY_READS_CONFIG_UNRESOLVED` (issues #152, #162)
+
+Design: `docs/design/specs/2026-08-28-config-key-family-design.md` (definitions
+side) and `docs/design/specs/2026-08-28-config-use-edge-design.md` (the
+`config_use` edge, this entry's main subject).
+
+- **Neutral vocabulary, same rule as `Artifact`/`Package`.** A yaml/env/ini
+  key is not a Python concept: label `ConfigKey`, edge `DEFINES_CONFIG`
+  (Artifact→ConfigKey), no `Py` prefix. Supersedes #152's earlier
+  `PyConfigKey`/`PY_DEFINES_CONFIG` naming (reconciled before either landed —
+  no migration). The Python-specific claim arrives only at the edge that
+  reads a key: `PY_USES_CONFIG` (`PyBodyNode`→`ConfigKey`, prop `prov:
+  string[]`) — one call site reads one key per edge, so no `_k` discriminant
+  is needed there.
+- **`PY_READS_CONFIG_UNRESOLVED` mirrors `PY_UNRESOLVED_IMPORT`'s shape**:
+  `PyApplication`→`:PyExternal` ghost of the callee (`os.getenv`, …), props
+  `key`, `reason` (`"non-literal"` | `"undefined-key"`), `prov`. Unlike
+  `PY_USES_CONFIG`, this one DOES carry a `_k` discriminant on `(key,
+  reason)` — the same external callee legitimately reads several distinct
+  undeclared/dynamic keys across one codebase, and a plain endpoint-pair
+  MERGE would collapse those onto one relationship, silently dropping every
+  key but the last one `SET`.
+- **Tier/prov model.** Three tiers, one shared `prov` vocabulary of exactly
+  two values — `"literal"` and `"dataflow"` (no separate intra/interproc
+  tag): literal (`-a 2`+, the call's key argument is a string constant),
+  dataflow-intra (`-a 3`+, DDG single-literal closure over the read's own
+  callable — `prov:["literal","dataflow"]` once a dataflow tier has been
+  attempted, matching the DDG's own `ssa`/`points-to` provenance-widening
+  precedent), dataflow-interproc (`-a 4`, one hop through the caller's
+  argument values via `call_graph`, never `param_in` traversal — a
+  controller ruling, since `param_in` is a value-flow overlay and this
+  closure only needs "what literal did every caller pass"). A read resolved
+  at a lower tier is never recomputed, so `-a 2 ⊆ -a 3 ⊆ -a 4` holds by
+  construction, gated the same as the DDG's own `ssa ⊆ points-to` widening.
+- **Sanctioned unresolved-complement.** `config_reads_unresolved` is
+  deliberately NOT monotonic — it shrinks as levels rise, the mirror image of
+  `config_uses` growing: a record a higher tier resolves migrates out of the
+  unresolved list and into an edge. The monotonicity gate binds the edge
+  SET; the unresolved list is that set's complement over "every detector
+  hit," in the same sanctioned-refinement family as the L1→L2 `callee:
+  null→id` change and the L2→L3 `BodyNode.parent: null→value` refinement
+  (#115) — a level is allowed to convert an absence into a presence, never
+  the reverse.
+- **Only `prov:["ssa"]` DDG edges close a literal.** `c.ddg` at `-a 4`
+  also carries `points-to` (may-alias widening) and `reaching-defs` (SDG
+  port-routing, #115) edges; a bare local can only ever be rebound by its
+  own name, so consulting anything but `ssa` for this specific closure is
+  never sound-adding, only noise that can kill a resolution the L3 ssa-only
+  set found cleanly. Reviewer-probed regression fixture:
+  `obj.attr = KEY` before `os.getenv(KEY)` — an attribute-write may-aliases
+  the bare `KEY` name it copies from (an unsuffixed local's empty suffix is
+  oracle-compatible with any attribute path in both `TypeBasedAliasOracle`
+  and the wrapped-fallback path of `ScalpelAliasOracle`), producing a
+  `points-to` edge whose def is not a `Name = <str Constant>` shape and so
+  unfilterably kills the closure at `-a 4` while `-a 3` (ssa-only by
+  construction) resolves cleanly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   formats (`.env`, `yaml`, `json`, `toml`, `ini`, `properties`), with
   reference recognition and `DEFINES_CONFIG` Neo4j projection; namespace
   discriminators per format (#152).
+- `PY_USES_CONFIG` edges from call sites to the `ConfigKey` they read,
+  resolved in three deterministic tiers: literal keys at `-a 2`, single-literal
+  def-use chains at `-a 3`, interprocedural parameter-passing chains at `-a 4`.
+  Unresolved reads (non-literal keys, undefined keys) emitted in
+  `application.config_reads_unresolved` with reasons; `PY_READS_CONFIG_UNRESOLVED`
+  Neo4j projection (#162).
 
 ## [1.2.0] - 2026-08-26
 

--- a/README.md
+++ b/README.md
@@ -493,8 +493,10 @@ Notable properties:
   (`can://python/<app>/<file>/<callable-sig>`); nodes below a callable use ordinal ids
   (`@entry`, `@exit`, `line:col`, `@formal_in:N`, `line:col/actual_in:N`).
 - **`source` lives once per module**; every node's text is the `module.source[span.bytes]` slice.
-- **Cross-function edges** — `call_graph`, `param_in`, `param_out` — live at **application** scope;
+- **Cross-function edges** — `call_graph`, `param_in`, `param_out`, `config_uses` — live at **application** scope;
   the intraprocedural `cfg`/`cdg`/`ddg` and the `summary` edges live **on the callable**.
+  `config_uses` resolve from call-site key arguments to `ConfigKey` nodes; unresolved reads
+  go to `config_reads_unresolved`.
 - **No dangling endpoints** — every `call_graph` `src`/`dst` joins the id space: declared
   callables by their tree id, imported/builtin targets by a `…/@external/<module>/<name>` id
   homed in `application.external_symbols`.

--- a/codeanalyzer/artifacts/__init__.py
+++ b/codeanalyzer/artifacts/__init__.py
@@ -6,7 +6,9 @@ text or binary -- issue #157 follow-up); extraction is narrow (only
 dependency manifests are parsed for meaning in this unit)."""
 
 from codeanalyzer.artifacts.config_keys import extract_config_keys, is_config_eligible
-from codeanalyzer.artifacts.config_use import detect_config_reads, resolve_uses
+from codeanalyzer.artifacts.config_use import (
+    dataflow_intra_tier, dataflow_interproc_tier, detect_config_reads, resolve_uses,
+)
 from codeanalyzer.artifacts.dependencies import build_dependency_view
 from codeanalyzer.artifacts.discovery import discover_artifacts
 
@@ -14,4 +16,5 @@ __all__ = [
     "discover_artifacts", "build_dependency_view",
     "extract_config_keys", "is_config_eligible",
     "detect_config_reads", "resolve_uses",
+    "dataflow_intra_tier", "dataflow_interproc_tier",
 ]

--- a/codeanalyzer/artifacts/__init__.py
+++ b/codeanalyzer/artifacts/__init__.py
@@ -6,10 +6,12 @@ text or binary -- issue #157 follow-up); extraction is narrow (only
 dependency manifests are parsed for meaning in this unit)."""
 
 from codeanalyzer.artifacts.config_keys import extract_config_keys, is_config_eligible
+from codeanalyzer.artifacts.config_use import detect_config_reads, resolve_uses
 from codeanalyzer.artifacts.dependencies import build_dependency_view
 from codeanalyzer.artifacts.discovery import discover_artifacts
 
 __all__ = [
     "discover_artifacts", "build_dependency_view",
     "extract_config_keys", "is_config_eligible",
+    "detect_config_reads", "resolve_uses",
 ]

--- a/codeanalyzer/artifacts/config_use.py
+++ b/codeanalyzer/artifacts/config_use.py
@@ -1,0 +1,255 @@
+"""config_use detection + resolution (#162): mints `PY_USES_CONFIG` edges
+between a call site's key argument and the `PyConfigKey` it reads, plus
+first-class unresolved records for a key that never closes on a literal.
+
+Two passes, wired from core.py's `>= 2` block after callee backfill and the
+config-keys extraction loop (both populate substrate this depends on --
+`BodyNode.callee` and `PyArtifact.config_keys`): `detect_config_reads` scans
+every callable's `body{}` for a `call` node whose `callee` names a
+`PyExternalSymbol` matching a shipped detector rule
+(`config_use_rules.yml`, same load/validate idiom as `entrypoints/rules.py`);
+`resolve_uses` decodes the matched call's key argument, resolves a string
+literal against `PyArtifact.config_keys` per the rule's namespace
+preference, and returns `(edges, unresolved)`. `tier_fns` is the extension
+point later dataflow tiers (#162 Task 3) plug into -- Task 2 only ships the
+literal tier, implemented directly in `resolve_uses`.
+
+Rule matching is prefix-aware on `module`, not exact-equal: empirically,
+`configparser.ConfigParser().get(...)` resolves (via the defuse linker) to
+callee module `configparser.RawConfigParser` -- `get` is inherited from the
+base class, not defined on `ConfigParser` itself -- so a strict `module ==
+"configparser"` would never match the shipped rule. `module == rule.module
+or module.startswith(rule.module + ".")` covers this without a per-rule
+alias list.
+
+Subscript caveat (controller ruling, verified empirically rather than
+assumed): `os.environ["X"]` is an `ast.Subscript`, and
+`_iter_calls_in_scope` (symbol_table_builder.py) only ever yields
+`ast.Call` nodes -- a probe project with an `os.environ[...]` read produces
+zero call body nodes for that statement
+(`test_environ_subscript_is_not_lowered_to_a_call_node`,
+test/test_config_use_literal.py). `os.getenv` and `os.environ.get` cover
+the `[env]` namespace in v1; the subscript form is a recorded gap, not a
+rule table entry -- there is no call node it could ever match.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+import yaml
+
+from codeanalyzer.schema.ids import ordinal_id
+from codeanalyzer.schema.py_schema import (
+    PyApplication, PyCallable, PyClass, PyConfigKey, PyConfigRead, PyConfigUseEdge,
+)
+
+_SHIPPED = Path(__file__).with_name("config_use_rules.yml")
+_TOP_LEVEL_KEYS = {"version", "rules"}
+_REQUIRED_RULE_KEYS = {"id", "module", "callable", "key_arg", "namespaces"}
+_OPTIONAL_RULE_KEYS = {"kwarg"}
+
+
+class ConfigUseRulesError(Exception):
+    """Raised for a malformed config_use_rules.yml. Never swallowed."""
+
+
+@dataclass(frozen=True)
+class Rule:
+    id: str
+    module: str
+    callable: str
+    key_arg: int
+    namespaces: Tuple[str, ...]
+    kwarg: Optional[str] = None  # not yet actionable -- see _key_from_args
+
+
+@dataclass(frozen=True)
+class _Read:
+    """One detector-matched call, before resolution."""
+
+    site: str  # GLOBAL ordinal id: <callable-id>@<local-id>
+    callee: str  # external id
+    rule: Rule
+    key_literal: Optional[str]  # decoded str, when the key arg is a str constant
+    key_name: Optional[str]  # bare Name identifier, when the key arg is a Name
+
+
+# A tier consumes the reads still unresolved after the ones before it, and
+# returns (new edges, reads still unresolved after this tier). Task 3 defines
+# the real dataflow tiers; Task 2's core.py wiring passes none, so only the
+# literal tier below (built into resolve_uses) ever runs.
+TierFn = Callable[[List[_Read], PyApplication], Tuple[List[PyConfigUseEdge], List[_Read]]]
+
+
+def load_rules(path: Path = _SHIPPED) -> List[Rule]:
+    try:
+        data = yaml.safe_load(path.read_text())
+    except FileNotFoundError as exc:
+        raise ConfigUseRulesError(f"rules file not found: {path}") from exc
+    except yaml.YAMLError as exc:
+        raise ConfigUseRulesError(f"{path}: invalid YAML: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ConfigUseRulesError(f"{path}: top level must be a mapping")
+    unknown = sorted(set(data) - _TOP_LEVEL_KEYS)
+    if unknown:
+        raise ConfigUseRulesError(f"{path}: unknown top-level key(s): {', '.join(unknown)}")
+    raw_rules = data.get("rules") or []
+    if not isinstance(raw_rules, list):
+        raise ConfigUseRulesError(f"{path}: `rules` must be a list")
+    return [_parse_rule(raw, path) for raw in raw_rules]
+
+
+def _parse_rule(raw: Dict, origin: Path) -> Rule:
+    if not isinstance(raw, dict):
+        raise ConfigUseRulesError(f"{origin}: rule entry must be a mapping: {raw!r}")
+    missing = _REQUIRED_RULE_KEYS - set(raw)
+    if missing:
+        raise ConfigUseRulesError(f"{origin}: rule {raw!r} missing {sorted(missing)}")
+    unknown = set(raw) - _REQUIRED_RULE_KEYS - _OPTIONAL_RULE_KEYS
+    if unknown:
+        raise ConfigUseRulesError(f"{origin}: rule {raw!r} has unknown key(s) {sorted(unknown)}")
+    namespaces = raw["namespaces"]
+    if not isinstance(namespaces, list) or not namespaces or not all(isinstance(n, str) for n in namespaces):
+        raise ConfigUseRulesError(
+            f"{origin}: rule {raw['id']!r} `namespaces` must be a non-empty list of strings"
+        )
+    return Rule(
+        id=raw["id"], module=raw["module"], callable=raw["callable"],
+        key_arg=int(raw["key_arg"]), namespaces=tuple(namespaces),
+        kwarg=raw.get("kwarg"),
+    )
+
+
+def _rule_matches(rule: Rule, module: Optional[str], name: str) -> bool:
+    if name != rule.callable:
+        return False
+    mod = module or ""
+    return mod == rule.module or mod.startswith(rule.module + ".")
+
+
+def _walk_callables(app: PyApplication):
+    def walk_callable(c: PyCallable):
+        yield c
+        for ic in (c.callables or {}).values():
+            yield from walk_callable(ic)
+        for cl in (c.types or {}).values():
+            yield from walk_class(cl)
+
+    def walk_class(cl: PyClass):
+        for m in (cl.callables or {}).values():
+            yield from walk_callable(m)
+        for ic in (cl.types or {}).values():
+            yield from walk_class(ic)
+
+    for mod in app.symbol_table.values():
+        for fn in (mod.functions or {}).values():
+            yield from walk_callable(fn)
+        for cl in (mod.types or {}).values():
+            yield from walk_class(cl)
+
+
+def _key_from_args(arguments, key_arg: int) -> Tuple[Optional[str], Optional[str]]:
+    """`(key_literal, key_name)` from the call's key-position argument.
+
+    Only positional args reach `BodyNode.arguments` (symbol_table_builder.py
+    only walks `node.args`, never `node.keywords`) -- a `kwarg=`-only call
+    (e.g. `cp.get(section, option="x")`) has no substrate to read the key
+    from, and this returns `(None, None)` for it same as a missing position.
+    """
+    if key_arg >= len(arguments):
+        return None, None
+    arg = arguments[key_arg]
+    literal = None
+    if arg.value is not None:
+        try:
+            decoded = json.loads(arg.value)
+        except json.JSONDecodeError:
+            decoded = None
+        if isinstance(decoded, str):
+            literal = decoded
+    return literal, arg.name
+
+
+def detect_config_reads(app: PyApplication, rules: Optional[Sequence[Rule]] = None) -> List[_Read]:
+    """Every call body node whose resolved callee matches a detector rule,
+    sorted by site for deterministic downstream iteration."""
+    rules = load_rules() if rules is None else rules
+    reads: List[_Read] = []
+    for c in _walk_callables(app):
+        for local_id, node in (c.body or {}).items():
+            if node.kind != "call" or not node.callee:
+                continue
+            sym = app.external_symbols.get(node.callee)
+            if sym is None:
+                continue
+            for rule in rules:
+                if not _rule_matches(rule, sym.module, sym.name):
+                    continue
+                key_literal, key_name = _key_from_args(node.arguments or [], rule.key_arg)
+                reads.append(_Read(
+                    site=ordinal_id(c.id, local_id), callee=node.callee,
+                    rule=rule, key_literal=key_literal, key_name=key_name,
+                ))
+                break  # (module, callable) is unambiguous across the shipped rule set
+    reads.sort(key=lambda r: (r.site, r.rule.id))
+    return reads
+
+
+def _namespace_matches(literal: str, namespace: str, keys: List[PyConfigKey]) -> List[PyConfigKey]:
+    if namespace == "env":
+        matched = [k for k in keys if k.key == literal]
+    else:  # ini/properties: the option name is the key's last dotted segment
+        matched = [k for k in keys if k.key == literal or k.key.endswith("." + literal)]
+    return sorted(matched, key=lambda k: k.id)
+
+
+def resolve_uses(
+    reads: List[_Read], app: PyApplication, tier_fns: Sequence[TierFn] = (),
+) -> Tuple[List[PyConfigUseEdge], List[PyConfigRead]]:
+    """Literal tier (built in here) then any dataflow `tier_fns` (Task 3) over
+    what's still unresolved. Reads resolved at a lower tier are never
+    recomputed -- additive, so `-a 2 ⊆ -a 3 ⊆ -a 4` holds by construction."""
+    keys_by_namespace: Dict[str, List[PyConfigKey]] = {}
+    for art in app.artifacts.values():
+        for key in art.config_keys:
+            keys_by_namespace.setdefault(key.namespace, []).append(key)
+
+    edges: List[PyConfigUseEdge] = []
+    unresolved: List[_Read] = []
+    for read in reads:
+        if read.key_literal is None:
+            unresolved.append(read)
+            continue
+        matched: List[PyConfigKey] = []
+        for namespace in read.rule.namespaces:
+            matched = _namespace_matches(read.key_literal, namespace, keys_by_namespace.get(namespace, []))
+            if matched:
+                break  # first namespace with >=1 match wins
+        if not matched:
+            unresolved.append(read)
+            continue
+        for key in matched:
+            edges.append(PyConfigUseEdge(src=read.site, dst=key.id, prov=["literal"]))
+
+    for tier_fn in tier_fns:
+        new_edges, unresolved = tier_fn(unresolved, app)
+        edges.extend(new_edges)
+
+    # Task 2 scope: only the literal tier above ever runs (core.py's L2 block
+    # passes no tier_fns), so every leftover read was tried at exactly that
+    # one tier. Task 3 must widen this to the tiers actually attempted once
+    # dataflow tier_fns exist.
+    unresolved_records = [
+        PyConfigRead(
+            site=r.site, callee=r.callee, key=r.key_literal,
+            reason="undefined-key" if r.key_literal is not None else "non-literal",
+            prov=["literal"],
+        )
+        for r in unresolved
+    ]
+    edges.sort(key=lambda e: (e.src, e.dst))
+    unresolved_records.sort(key=lambda u: (u.site, u.reason, u.key or ""))
+    return edges, unresolved_records

--- a/codeanalyzer/artifacts/config_use.py
+++ b/codeanalyzer/artifacts/config_use.py
@@ -2,17 +2,43 @@
 between a call site's key argument and the `PyConfigKey` it reads, plus
 first-class unresolved records for a key that never closes on a literal.
 
-Two passes, wired from core.py's `>= 2` block after callee backfill and the
-config-keys extraction loop (both populate substrate this depends on --
-`BodyNode.callee` and `PyArtifact.config_keys`): `detect_config_reads` scans
-every callable's `body{}` for a `call` node whose `callee` names a
-`PyExternalSymbol` matching a shipped detector rule
-(`config_use_rules.yml`, same load/validate idiom as `entrypoints/rules.py`);
-`resolve_uses` decodes the matched call's key argument, resolves a string
-literal against `PyArtifact.config_keys` per the rule's namespace
-preference, and returns `(edges, unresolved)`. `tier_fns` is the extension
-point later dataflow tiers (#162 Task 3) plug into -- Task 2 only ships the
-literal tier, implemented directly in `resolve_uses`.
+Three tiers, wired from core.py: `detect_config_reads` runs once, after
+callee backfill and the config-keys extraction loop (both populate
+substrate this depends on -- `BodyNode.callee` and `PyArtifact.config_keys`),
+scanning every callable's `body{}` for a `call` node whose `callee` names a
+`PyExternalSymbol` matching a shipped detector rule (`config_use_rules.yml`,
+same load/validate idiom as `entrypoints/rules.py`). `resolve_uses` decodes
+each matched call's key argument, resolves a string literal against
+`PyArtifact.config_keys` per the rule's namespace preference (the literal
+tier, built in directly), then threads whatever is still unresolved through
+`tier_fns` in order -- core.py passes `[dataflow_intra_tier]` at `-a 3` and
+`[dataflow_intra_tier, dataflow_interproc_tier]` at `-a 4` (#162 Task 3),
+so a read resolved at a lower tier is never recomputed and `-a 2 ⊆ -a 3 ⊆
+-a 4` holds by construction.
+
+`dataflow_intra_tier` closes a non-literal key argument (`_Read.key_name`)
+over its own callable's DDG: `_reaching_literal` finds every DDG edge for
+that variable whose destination node's span *contains* the call's span --
+not `== the call's own local id` as a first reading of the plan suggests,
+because the CFG (and hence the DDG) is statement-level (`dataflow/cfg.py`)
+while a call nested in `return`/an assignment gets its own, narrower body-key
+span (`schema/l1_body.py`); containment is what actually finds the reaching
+def for `return os.getenv(KEY)` as well as a bare `os.getenv(KEY)` statement
+(where call and statement spans coincide) -- verified empirically against
+both shapes before landing this. Each reaching def must slice+parse to
+exactly one `Name = <str Constant>` Assign; multiple reaching defs must all
+yield the *same* literal (spec caveat: identical duplicates count as closed).
+`dataflow_interproc_tier` handles a key that names a *parameter* of its
+enclosing callable: every call site targeting that callable (`call_graph`
+join, then a `body` scan for the matching `callee` id -- never `param_in`,
+controller ruling) must supply the same string literal at that parameter's
+position, either directly (`PyCallArgument.value`) or by one non-recursive
+hop of the same intra closure at the *caller*'s own call site (`visited`
+seeded with the callee id guards the direct-self-recursion case). Both
+tiers re-resolve a closed literal against `PyArtifact.config_keys` through
+the same namespace-preference helper the literal tier uses, so a value that
+closes but names no declared key still becomes `reason="undefined-key"`
+rather than `"non-literal"`.
 
 Rule matching is prefix-aware on `module`, not exact-equal: empirically,
 `configparser.ConfigParser().get(...)` resolves (via the defuse linker) to
@@ -34,16 +60,18 @@ rule table entry -- there is no call node it could ever match.
 """
 from __future__ import annotations
 
+import ast
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple
 
 import yaml
 
 from codeanalyzer.schema.ids import ordinal_id
 from codeanalyzer.schema.py_schema import (
-    PyApplication, PyCallable, PyClass, PyConfigKey, PyConfigRead, PyConfigUseEdge,
+    BodyNode, PyApplication, PyCallable, PyClass, PyConfigKey, PyConfigRead,
+    PyConfigUseEdge, PyModule,
 )
 
 _SHIPPED = Path(__file__).with_name("config_use_rules.yml")
@@ -71,6 +99,11 @@ class _Read:
     """One detector-matched call, before resolution."""
 
     site: str  # GLOBAL ordinal id: <callable-id>@<local-id>
+    # `callable_id`/`local_id`: the dataflow tiers' join point back to the
+    # enclosing callable's `.ddg`/`.body` (and, for the interproc tier, its
+    # `.parameters` and `call_graph` membership as a callee).
+    callable_id: str  # the enclosing callable's can:// id
+    local_id: str  # the call node's own LOCAL id within `callable_id`'s body
     callee: str  # external id
     rule: Rule
     key_literal: Optional[str]  # decoded str, when the key arg is a str constant
@@ -78,9 +111,10 @@ class _Read:
 
 
 # A tier consumes the reads still unresolved after the ones before it, and
-# returns (new edges, reads still unresolved after this tier). Task 3 defines
-# the real dataflow tiers; Task 2's core.py wiring passes none, so only the
-# literal tier below (built into resolve_uses) ever runs.
+# returns (new edges, reads still unresolved after this tier). core.py wires
+# `[dataflow_intra_tier]` at `-a 3` and `[dataflow_intra_tier,
+# dataflow_interproc_tier]` at `-a 4`; the literal tier (built into
+# resolve_uses) always runs first, regardless of level.
 TierFn = Callable[[List[_Read], PyApplication], Tuple[List[PyConfigUseEdge], List[_Read]]]
 
 
@@ -130,25 +164,43 @@ def _rule_matches(rule: Rule, module: Optional[str], name: str) -> bool:
     return mod == rule.module or mod.startswith(rule.module + ".")
 
 
+def _walk_callable_tree(c: PyCallable):
+    yield c
+    for ic in (c.callables or {}).values():
+        yield from _walk_callable_tree(ic)
+    for cl in (c.types or {}).values():
+        yield from _walk_class_tree(cl)
+
+
+def _walk_class_tree(cl: PyClass):
+    for m in (cl.callables or {}).values():
+        yield from _walk_callable_tree(m)
+    for ic in (cl.types or {}).values():
+        yield from _walk_class_tree(ic)
+
+
+def _walk_module_callables(mod: PyModule):
+    for fn in (mod.functions or {}).values():
+        yield from _walk_callable_tree(fn)
+    for cl in (mod.types or {}).values():
+        yield from _walk_class_tree(cl)
+
+
 def _walk_callables(app: PyApplication):
-    def walk_callable(c: PyCallable):
-        yield c
-        for ic in (c.callables or {}).values():
-            yield from walk_callable(ic)
-        for cl in (c.types or {}).values():
-            yield from walk_class(cl)
-
-    def walk_class(cl: PyClass):
-        for m in (cl.callables or {}).values():
-            yield from walk_callable(m)
-        for ic in (cl.types or {}).values():
-            yield from walk_class(ic)
-
     for mod in app.symbol_table.values():
-        for fn in (mod.functions or {}).values():
-            yield from walk_callable(fn)
-        for cl in (mod.types or {}).values():
-            yield from walk_class(cl)
+        yield from _walk_module_callables(mod)
+
+
+def _index_callables(app: PyApplication) -> Dict[str, Tuple[PyCallable, str]]:
+    """``callable id -> (callable, owning module's source)`` -- the dataflow
+    tiers' join point from a read's/call-graph's callable id back to the
+    `.ddg`/`.body` data (and the module `source` needed to slice a def's
+    span text) that the intra closure reads."""
+    return {
+        c.id: (c, mod.source)
+        for mod in app.symbol_table.values()
+        for c in _walk_module_callables(mod)
+    }
 
 
 def _key_from_args(arguments, key_arg: int) -> Tuple[Optional[str], Optional[str]]:
@@ -190,8 +242,8 @@ def detect_config_reads(app: PyApplication, rules: Optional[Sequence[Rule]] = No
                     continue
                 key_literal, key_name = _key_from_args(node.arguments or [], rule.key_arg)
                 reads.append(_Read(
-                    site=ordinal_id(c.id, local_id), callee=node.callee,
-                    rule=rule, key_literal=key_literal, key_name=key_name,
+                    site=ordinal_id(c.id, local_id), callable_id=c.id, local_id=local_id,
+                    callee=node.callee, rule=rule, key_literal=key_literal, key_name=key_name,
                 ))
                 break  # (module, callable) is unambiguous across the shipped rule set
     reads.sort(key=lambda r: (r.site, r.rule.id))
@@ -206,16 +258,35 @@ def _namespace_matches(literal: str, namespace: str, keys: List[PyConfigKey]) ->
     return sorted(matched, key=lambda k: k.id)
 
 
+def _keys_by_namespace(app: PyApplication) -> Dict[str, List[PyConfigKey]]:
+    keys_by_namespace: Dict[str, List[PyConfigKey]] = {}
+    for art in app.artifacts.values():
+        for key in art.config_keys:
+            keys_by_namespace.setdefault(key.namespace, []).append(key)
+    return keys_by_namespace
+
+
+def _resolve_literal_against_keys(
+    rule: Rule, literal: str, keys_by_namespace: Dict[str, List[PyConfigKey]],
+) -> List[PyConfigKey]:
+    """The matched `PyConfigKey`s for `literal` under `rule`'s namespace
+    preference order -- the first namespace with >=1 match wins, shared by
+    the literal tier and both dataflow tiers so a closed-but-undeclared key
+    is `reason="undefined-key"` regardless of which tier closed it."""
+    for namespace in rule.namespaces:
+        matched = _namespace_matches(literal, namespace, keys_by_namespace.get(namespace, []))
+        if matched:
+            return matched
+    return []
+
+
 def resolve_uses(
     reads: List[_Read], app: PyApplication, tier_fns: Sequence[TierFn] = (),
 ) -> Tuple[List[PyConfigUseEdge], List[PyConfigRead]]:
     """Literal tier (built in here) then any dataflow `tier_fns` (Task 3) over
     what's still unresolved. Reads resolved at a lower tier are never
     recomputed -- additive, so `-a 2 ⊆ -a 3 ⊆ -a 4` holds by construction."""
-    keys_by_namespace: Dict[str, List[PyConfigKey]] = {}
-    for art in app.artifacts.values():
-        for key in art.config_keys:
-            keys_by_namespace.setdefault(key.namespace, []).append(key)
+    keys_by_namespace = _keys_by_namespace(app)
 
     edges: List[PyConfigUseEdge] = []
     unresolved: List[_Read] = []
@@ -223,11 +294,7 @@ def resolve_uses(
         if read.key_literal is None:
             unresolved.append(read)
             continue
-        matched: List[PyConfigKey] = []
-        for namespace in read.rule.namespaces:
-            matched = _namespace_matches(read.key_literal, namespace, keys_by_namespace.get(namespace, []))
-            if matched:
-                break  # first namespace with >=1 match wins
+        matched = _resolve_literal_against_keys(read.rule, read.key_literal, keys_by_namespace)
         if not matched:
             unresolved.append(read)
             continue
@@ -238,18 +305,215 @@ def resolve_uses(
         new_edges, unresolved = tier_fn(unresolved, app)
         edges.extend(new_edges)
 
-    # Task 2 scope: only the literal tier above ever runs (core.py's L2 block
-    # passes no tier_fns), so every leftover read was tried at exactly that
-    # one tier. Task 3 must widen this to the tiers actually attempted once
-    # dataflow tier_fns exist.
+    # `prov` lists every tier attempted: the literal tier always runs (above);
+    # `tier_fns` non-empty means some dataflow tier(s) ran too -- the
+    # vocabulary is exactly "literal"/"dataflow" (no separate intra/interproc
+    # tag), so intra-only (-a 3) and intra+interproc (-a 4) both read the same.
+    attempted = ["literal"] + (["dataflow"] if tier_fns else [])
     unresolved_records = [
         PyConfigRead(
             site=r.site, callee=r.callee, key=r.key_literal,
             reason="undefined-key" if r.key_literal is not None else "non-literal",
-            prov=["literal"],
+            prov=attempted,
         )
         for r in unresolved
     ]
     edges.sort(key=lambda e: (e.src, e.dst))
     unresolved_records.sort(key=lambda u: (u.site, u.reason, u.key or ""))
     return edges, unresolved_records
+
+
+# --- dataflow tiers (#162 Task 3) -------------------------------------------
+
+
+def _assign_literal(source: str, def_node: Optional[BodyNode]) -> Optional[str]:
+    """The str constant a single reaching def closes on, or `None` if
+    `def_node` isn't exactly a single-target `Name = <str Constant>` Assign
+    (a formal-parameter binding has no span; a `for`-header or multi-target
+    assign fails to parse/shape-match -- both correctly never close)."""
+    if def_node is None or def_node.span is None:
+        return None
+    lo, hi = def_node.span.bytes
+    text = source.encode("utf-8")[lo:hi].decode("utf-8")
+    try:
+        parsed = ast.parse(text)
+    except SyntaxError:
+        return None
+    if len(parsed.body) != 1:
+        return None
+    stmt = parsed.body[0]
+    if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1 or not isinstance(stmt.targets[0], ast.Name):
+        return None
+    value = stmt.value
+    if isinstance(value, ast.Constant) and isinstance(value.value, str):
+        return value.value
+    return None
+
+
+def _reaching_literal(c: PyCallable, source: str, use_local_id: str, var: str) -> Optional[str]:
+    """The one string literal every DDG-reaching def of `var` at
+    `use_local_id` closes on -- `None` if nothing reaches, any reaching def
+    isn't a literal assignment, or reaching defs disagree (identical
+    duplicates count as one, per the spec caveat).
+
+    `use_local_id` is a `call` node's own local id, keyed by its own
+    (typically narrower) span -- but the CFG/DDG is statement-level
+    (`dataflow/cfg.py`), so a def's DDG-recorded *use* site is the
+    *enclosing statement's* local id, which only coincides with the call's
+    own id when the call is itself a bare expression statement. Matching by
+    span containment (the def's dst node's span contains the call's span)
+    covers both that coincidence and the common case of a call nested in a
+    `return`/assignment, without needing to special-case either shape.
+    """
+    use_node = c.body.get(use_local_id)
+    if use_node is None or use_node.span is None:
+        return None
+    lo, hi = use_node.span.bytes
+    literals: Set[str] = set()
+    reached = False
+    for edge in c.ddg:
+        if edge.var != var:
+            continue
+        dst_node = c.body.get(edge.dst)
+        if dst_node is None or dst_node.span is None:
+            continue
+        d_lo, d_hi = dst_node.span.bytes
+        if not (d_lo <= lo and hi <= d_hi):
+            continue  # this DDG use is some other reference to `var`, not this call's
+        reached = True
+        literal = _assign_literal(source, c.body.get(edge.src))
+        if literal is None:
+            return None  # any non-closing reaching def kills resolution
+        literals.add(literal)
+    if not reached or len(literals) != 1:
+        return None
+    return next(iter(literals))
+
+
+def dataflow_intra_tier(reads: List[_Read], app: PyApplication) -> Tuple[List[PyConfigUseEdge], List[_Read]]:
+    """L3 tier: close a non-literal key argument over its own callable's DDG
+    (`_reaching_literal`), then resolve the closed literal against
+    `PyArtifact.config_keys` exactly like the literal tier does."""
+    index = _index_callables(app)
+    keys_by_namespace = _keys_by_namespace(app)
+    edges: List[PyConfigUseEdge] = []
+    unresolved: List[_Read] = []
+    for read in reads:
+        entry = index.get(read.callable_id)
+        if read.key_name is None or entry is None:
+            unresolved.append(read)
+            continue
+        c, source = entry
+        literal = _reaching_literal(c, source, read.local_id, read.key_name)
+        if literal is None:
+            unresolved.append(read)
+            continue
+        matched = _resolve_literal_against_keys(read.rule, literal, keys_by_namespace)
+        if not matched:
+            unresolved.append(replace(read, key_literal=literal))
+            continue
+        for key in matched:
+            edges.append(PyConfigUseEdge(src=read.site, dst=key.id, prov=["dataflow"]))
+    return edges, unresolved
+
+
+def _call_sites_targeting(
+    app: PyApplication, index: Dict[str, Tuple[PyCallable, str]], target_id: str,
+) -> List[Tuple[PyCallable, str, str, BodyNode]]:
+    """Every `(caller, caller_source, local_id, call_node)` whose `callee`
+    is `target_id` -- the call-graph join (which callables call it) narrowed
+    to the actual call-site body nodes (which arguments they pass), sorted
+    for deterministic iteration."""
+    caller_ids = sorted({e.src for e in app.call_graph if e.dst == target_id})
+    sites: List[Tuple[PyCallable, str, str, BodyNode]] = []
+    for caller_id in caller_ids:
+        entry = index.get(caller_id)
+        if entry is None:
+            continue
+        caller, source = entry
+        for local_id, node in sorted((caller.body or {}).items()):
+            if node.kind == "call" and node.callee == target_id:
+                sites.append((caller, source, local_id, node))
+    return sites
+
+
+def _site_literal(
+    node: BodyNode, param_index: int, caller: PyCallable, source: str, local_id: str, visited: Set[str],
+) -> Optional[str]:
+    """This call site's contribution to closing the callee's parameter: the
+    str literal passed directly at `param_index`, or -- when that argument
+    is itself a bare Name -- one non-recursive hop of `_reaching_literal` at
+    the *caller*'s own call site (guarded by `visited` against the direct
+    self-recursive-call case). Only positional args reach `BodyNode.arguments`
+    (same substrate limitation `_key_from_args` documents), so a kwarg-only
+    or too-short call site contributes nothing -- `None`, same as any other
+    non-closing site, which is enough to leave the read unresolved."""
+    args = node.arguments or []
+    if param_index >= len(args):
+        return None
+    arg = args[param_index]
+    if arg.value is not None:
+        try:
+            decoded = json.loads(arg.value)
+        except json.JSONDecodeError:
+            return None
+        return decoded if isinstance(decoded, str) else None
+    if arg.name is not None and caller.id not in visited:
+        return _reaching_literal(caller, source, local_id, arg.name)
+    return None
+
+
+def dataflow_interproc_tier(
+    reads: List[_Read], app: PyApplication,
+) -> Tuple[List[PyConfigUseEdge], List[_Read]]:
+    """L4 tier: a key that names a *parameter* of its enclosing callable
+    closes when every call site targeting that callable supplies the same
+    string literal (directly, or via one hop of caller-side intra closure)
+    -- call-graph + caller argument values only, never `param_in` traversal
+    (controller ruling)."""
+    index = _index_callables(app)
+    keys_by_namespace = _keys_by_namespace(app)
+    edges: List[PyConfigUseEdge] = []
+    unresolved: List[_Read] = []
+    for read in reads:
+        entry = index.get(read.callable_id)
+        # `key_literal` already set means the intra tier closed this read to
+        # a literal that simply named no declared key (e.g. a parameter
+        # shadowed by a local reassignment the intra tier correctly traced
+        # instead) -- that is this read's real value; re-deriving one from
+        # the *callers'* arguments here would ignore the shadow and can
+        # misattribute a caller-supplied value to a name the callee never
+        # actually reads.
+        if read.key_name is None or read.key_literal is not None or entry is None:
+            unresolved.append(read)
+            continue
+        c, _source = entry
+        param_names = [p.name for p in c.parameters or []]
+        if read.key_name not in param_names:
+            unresolved.append(read)
+            continue
+        param_index = param_names.index(read.key_name)
+        sites = _call_sites_targeting(app, index, c.id)
+        if not sites:
+            unresolved.append(read)
+            continue
+        visited = {c.id}  # guards the direct self-recursive-call case
+        literals: Set[str] = set()
+        all_closed = True
+        for caller, source, local_id, node in sites:
+            literal = _site_literal(node, param_index, caller, source, local_id, visited)
+            if literal is None:
+                all_closed = False
+                break
+            literals.add(literal)
+        if not all_closed or len(literals) != 1:
+            unresolved.append(read)
+            continue
+        literal = next(iter(literals))
+        matched = _resolve_literal_against_keys(read.rule, literal, keys_by_namespace)
+        if not matched:
+            unresolved.append(replace(read, key_literal=literal))
+            continue
+        for key in matched:
+            edges.append(PyConfigUseEdge(src=read.site, dst=key.id, prov=["dataflow"]))
+    return edges, unresolved

--- a/codeanalyzer/artifacts/config_use.py
+++ b/codeanalyzer/artifacts/config_use.py
@@ -150,10 +150,13 @@ def _parse_rule(raw: Dict, origin: Path) -> Rule:
         raise ConfigUseRulesError(
             f"{origin}: rule {raw['id']!r} `namespaces` must be a non-empty list of strings"
         )
+    kwarg = raw.get("kwarg")
+    if kwarg is not None and not isinstance(kwarg, str):
+        raise ConfigUseRulesError(f"{origin}: rule {raw['id']!r} `kwarg` must be a string")
     return Rule(
         id=raw["id"], module=raw["module"], callable=raw["callable"],
         key_arg=int(raw["key_arg"]), namespaces=tuple(namespaces),
-        kwarg=raw.get("kwarg"),
+        kwarg=kwarg,
     )
 
 

--- a/codeanalyzer/artifacts/config_use.py
+++ b/codeanalyzer/artifacts/config_use.py
@@ -333,7 +333,11 @@ def _assign_literal(source: str, def_node: Optional[BodyNode]) -> Optional[str]:
     """The str constant a single reaching def closes on, or `None` if
     `def_node` isn't exactly a single-target `Name = <str Constant>` Assign
     (a formal-parameter binding has no span; a `for`-header or multi-target
-    assign fails to parse/shape-match -- both correctly never close)."""
+    assign fails to parse/shape-match -- both correctly never close).
+    Also rejected by design, not just incidentally: `ast.AnnAssign`
+    (`KEY: str = "X"`), `ast.AugAssign` (`KEY += "X"`), and tuple-unpack
+    (`KEY, other = ...`) -- none is a plain single-target `Name = <str
+    Constant>` Assign."""
     if def_node is None or def_node.span is None:
         return None
     lo, hi = def_node.span.bytes

--- a/codeanalyzer/artifacts/config_use.py
+++ b/codeanalyzer/artifacts/config_use.py
@@ -371,6 +371,18 @@ def _reaching_literal(c: PyCallable, source: str, use_local_id: str, var: str) -
     span containment (the def's dst node's span contains the call's span)
     covers both that coincidence and the common case of a call nested in a
     `return`/assignment, without needing to special-case either shape.
+
+    Only `prov=["ssa"]` edges are consulted: at `-a 4`
+    `c.ddg` also carries `points-to` (may-alias widening) and `reaching-defs`
+    (SDG port-routing, #115) edges. An alias edge can connect this `var`'s
+    use to an unrelated attribute-write def -- `obj.attr = KEY` may-aliases
+    bare `KEY` itself, since an unsuffixed local's empty suffix is
+    oracle-compatible with any attribute path -- that is never a `Name =
+    <str Constant>` shape, so `_assign_literal` correctly refuses it; left
+    unfiltered, that refusal then kills a closure the ssa-only L3 set
+    resolved cleanly, breaking the `-a 3 ⊆ -a 4` monotonicity contract. A
+    bare local can only ever be rebound by its own name, so widening past
+    ssa here is never sound-adding, only noise.
     """
     use_node = c.body.get(use_local_id)
     if use_node is None or use_node.span is None:
@@ -379,7 +391,7 @@ def _reaching_literal(c: PyCallable, source: str, use_local_id: str, var: str) -
     literals: Set[str] = set()
     reached = False
     for edge in c.ddg:
-        if edge.var != var:
+        if edge.var != var or "ssa" not in (edge.prov or []):
             continue
         dst_node = c.body.get(edge.dst)
         if dst_node is None or dst_node.span is None:
@@ -426,22 +438,37 @@ def dataflow_intra_tier(reads: List[_Read], app: PyApplication) -> Tuple[List[Py
 
 def _call_sites_targeting(
     app: PyApplication, index: Dict[str, Tuple[PyCallable, str]], target_id: str,
-) -> List[Tuple[PyCallable, str, str, BodyNode]]:
+) -> Tuple[List[Tuple[PyCallable, str, str, BodyNode]], bool]:
     """Every `(caller, caller_source, local_id, call_node)` whose `callee`
     is `target_id` -- the call-graph join (which callables call it) narrowed
     to the actual call-site body nodes (which arguments they pass), sorted
-    for deterministic iteration."""
+    for deterministic iteration.
+
+    The second return value is completeness: False
+    when some `call_graph` caller of `target_id` can't be accounted for in
+    `sites` -- either it never resolves in `index` (a module-scope caller's
+    `src` is a `can://.../@external/<module>` id, #131 modeling --
+    `_index_callables` only ever holds declared callables) or it resolves
+    but contributes zero matching call-site body nodes. Either way, "every
+    site agrees" computed only over `sites` would silently speak for a
+    caller it never actually saw."""
     caller_ids = sorted({e.src for e in app.call_graph if e.dst == target_id})
     sites: List[Tuple[PyCallable, str, str, BodyNode]] = []
+    complete = True
     for caller_id in caller_ids:
         entry = index.get(caller_id)
         if entry is None:
+            complete = False
             continue
         caller, source = entry
+        seen_here = False
         for local_id, node in sorted((caller.body or {}).items()):
             if node.kind == "call" and node.callee == target_id:
                 sites.append((caller, source, local_id, node))
-    return sites
+                seen_here = True
+        if not seen_here:
+            complete = False
+    return sites, complete
 
 
 def _site_literal(
@@ -470,14 +497,53 @@ def _site_literal(
     return None
 
 
+_ENTRY_KINDS = {"entry", "formal_in"}  # a param's implicit binding, never a rebind
+
+
+def _locally_redefined(c: PyCallable, use_local_id: str, var: str) -> bool:
+    """True when some ssa DDG-reaching def of `var` at `use_local_id` is a
+    real statement -- not the callable's own implicit `@entry`/`@formal_in`
+    parameter binding.
+
+    An unshadowed parameter's only reaching def IS that implicit binding
+    (`access_paths.def_use_facts`: ENTRY defines every param as the
+    function's incoming state), so this is False for it -- the interproc
+    tier's caller-argument closure is safe. A parameter reassigned anywhere
+    on a path reaching the read -- even conditionally, even to a non-literal
+    value the intra tier can't close and so leaves `key_literal` at `None`
+    rather than "closed-but-undeclared" -- has at least one real statement
+    def here, and the caller's argument can no longer be assumed to be what
+    the read actually sees. Same span-containment reaching-def match
+    `_reaching_literal` uses, minus the literal-closing requirement."""
+    use_node = c.body.get(use_local_id)
+    if use_node is None or use_node.span is None:
+        return False
+    lo, hi = use_node.span.bytes
+    for edge in c.ddg:
+        if edge.var != var or "ssa" not in (edge.prov or []):
+            continue
+        dst_node = c.body.get(edge.dst)
+        if dst_node is None or dst_node.span is None:
+            continue
+        d_lo, d_hi = dst_node.span.bytes
+        if not (d_lo <= lo and hi <= d_hi):
+            continue
+        src_node = c.body.get(edge.src)
+        if src_node is not None and src_node.kind not in _ENTRY_KINDS:
+            return True
+    return False
+
+
 def dataflow_interproc_tier(
     reads: List[_Read], app: PyApplication,
 ) -> Tuple[List[PyConfigUseEdge], List[_Read]]:
     """L4 tier: a key that names a *parameter* of its enclosing callable
-    closes when every call site targeting that callable supplies the same
-    string literal (directly, or via one hop of caller-side intra closure)
-    -- call-graph + caller argument values only, never `param_in` traversal
-    (controller ruling)."""
+    closes when the parameter is never locally redefined (`_locally_
+    redefined`) and every call site targeting that callable -- ALL of
+    them, `_call_sites_targeting`'s completeness flag -- supplies the
+    same string literal (directly, or via one hop of caller-side intra
+    closure) -- call-graph + caller argument values only, never `param_in`
+    traversal (controller ruling)."""
     index = _index_callables(app)
     keys_by_namespace = _keys_by_namespace(app)
     edges: List[PyConfigUseEdge] = []
@@ -499,9 +565,14 @@ def dataflow_interproc_tier(
         if read.key_name not in param_names:
             unresolved.append(read)
             continue
+        if _locally_redefined(c, read.local_id, read.key_name):
+            # Locally rebound on some path through the callable's own body --
+            # a caller's argument is not provably what the read sees.
+            unresolved.append(read)
+            continue
         param_index = param_names.index(read.key_name)
-        sites = _call_sites_targeting(app, index, c.id)
-        if not sites:
+        sites, complete = _call_sites_targeting(app, index, c.id)
+        if not sites or not complete:
             unresolved.append(read)
             continue
         visited = {c.id}  # guards the direct self-recursive-call case

--- a/codeanalyzer/artifacts/config_use_rules.yml
+++ b/codeanalyzer/artifacts/config_use_rules.yml
@@ -1,0 +1,58 @@
+version: 1
+
+# Shipped config-use detector table (#162), spec §3. Each rule identifies a
+# call whose resolved callee is `module.callable` (matched prefix-aware on
+# `module` -- see config_use.py's module docstring for why) and which
+# argument position carries the key. No user-extension flag yet (matches
+# the artifact rules posture).
+#
+# `os.environ.__getitem__` (the `os.environ["X"]` subscript form) is
+# deliberately absent: verified empirically that a subscript never lowers
+# to a call body node, so there is no call this rule could ever match
+# (config_use.py's module docstring has the finding).
+rules:
+  - id: os.getenv
+    module: os
+    callable: getenv
+    key_arg: 0
+    namespaces: [env]
+
+  - id: os.environ.get
+    module: os.environ
+    callable: get
+    key_arg: 0
+    namespaces: [env]
+
+  - id: dotenv.get_key
+    module: dotenv
+    callable: get_key
+    key_arg: 1
+    namespaces: [env]
+
+  - id: configparser.get
+    module: configparser
+    callable: get
+    key_arg: 1
+    kwarg: option
+    namespaces: [ini, properties]
+
+  - id: configparser.getint
+    module: configparser
+    callable: getint
+    key_arg: 1
+    kwarg: option
+    namespaces: [ini, properties]
+
+  - id: configparser.getfloat
+    module: configparser
+    callable: getfloat
+    key_arg: 1
+    kwarg: option
+    namespaces: [ini, properties]
+
+  - id: configparser.getboolean
+    module: configparser
+    callable: getboolean
+    key_arg: 1
+    kwarg: option
+    namespaces: [ini, properties]

--- a/codeanalyzer/core.py
+++ b/codeanalyzer/core.py
@@ -704,6 +704,16 @@ class Codeanalyzer:
             elif art.extraction == "none":
                 art.extraction = "full"
 
+        # config_use (#162): literal tier. Needs callees resolved (backfill_
+        # callees above, gated the same >= 2) and config_keys just extracted
+        # above, so this runs after both rather than immediately following
+        # the callee backfill call itself.
+        if self.analysis_level >= 2:
+            from codeanalyzer.artifacts import detect_config_reads, resolve_uses
+
+            reads = detect_config_reads(app)
+            app.config_uses, app.config_reads_unresolved = resolve_uses(reads, app)
+
         # L3: intraprocedural dataflow (CFG/CDG/DDG) emitted onto the v2 tree.
         if self.analysis_level >= 3:
             from codeanalyzer.dataflow.builder import (

--- a/codeanalyzer/core.py
+++ b/codeanalyzer/core.py
@@ -704,15 +704,17 @@ class Codeanalyzer:
             elif art.extraction == "none":
                 art.extraction = "full"
 
-        # config_use (#162): literal tier. Needs callees resolved (backfill_
+        # config_use (#162) detection: needs callees resolved (backfill_
         # callees above, gated the same >= 2) and config_keys just extracted
         # above, so this runs after both rather than immediately following
-        # the callee backfill call itself.
+        # the callee backfill call itself. Resolution is deferred past the
+        # L3/L4 blocks below (the dataflow tiers need DDG and call_graph/
+        # caller-argument substrate those blocks populate) and gated by
+        # level there, literal tier included.
         if self.analysis_level >= 2:
-            from codeanalyzer.artifacts import detect_config_reads, resolve_uses
+            from codeanalyzer.artifacts import detect_config_reads
 
-            reads = detect_config_reads(app)
-            app.config_uses, app.config_reads_unresolved = resolve_uses(reads, app)
+            config_reads = detect_config_reads(app)
 
         # L3: intraprocedural dataflow (CFG/CDG/DDG) emitted onto the v2 tree.
         if self.analysis_level >= 3:
@@ -753,6 +755,29 @@ class Codeanalyzer:
             # oracle adds beyond the L3 syntactic set, tagged prov=["points-to"].
             # ``infos`` are the syntactic (L3) PDGs from the >=3 block above.
             emit_ddg_pointsto_delta(app, infos, ir, sig_to_id)
+
+        # config_use (#162) resolution: literal tier always runs at >= 2;
+        # the dataflow tiers widen the set as substrate comes online -- intra
+        # needs the DDG the L3 block above just emitted, interproc needs
+        # call_graph + caller PyCallArgument values (already present since
+        # L2) plus, for its one-hop caller-side closure, the caller's own
+        # DDG -- populated for every callable by the same L3 block, which
+        # always runs before this when analysis_level >= 4. A read resolved
+        # at a lower tier is never recomputed, so `-a 2 ⊆ -a 3 ⊆ -a 4` holds
+        # by construction.
+        if self.analysis_level >= 2:
+            from codeanalyzer.artifacts import (
+                dataflow_intra_tier, dataflow_interproc_tier, resolve_uses,
+            )
+
+            tier_fns = []
+            if self.analysis_level >= 3:
+                tier_fns.append(dataflow_intra_tier)
+            if self.analysis_level >= 4:
+                tier_fns.append(dataflow_interproc_tier)
+            app.config_uses, app.config_reads_unresolved = resolve_uses(
+                config_reads, app, tier_fns=tier_fns
+            )
 
         # Build the v2 envelope, then persist it (the cache stores the full
         # ``Analysis`` envelope so a reused cache round-trips schema_version).

--- a/codeanalyzer/dataflow/builder.py
+++ b/codeanalyzer/dataflow/builder.py
@@ -353,6 +353,10 @@ def build_program_graphs(
     """
     class_idx = _class_index(app)
     callable_idx = _callable_index(app)
+    # Reverse of callable_idx: a callsite's already-L2-backfilled BodyNode.callee
+    # (a can:// id, folding in the defuse linker's resolution -- not just Jedi's
+    # own callee_signature side channel) resolved back to a dotted signature.
+    id_to_sig = {c.id: sig for sig, c in callable_idx.items()}
 
     infos, func_asts = build_function_pdgs(app, k, oracle_factory=oracle_factory)
 
@@ -373,7 +377,17 @@ def build_program_graphs(
                 calls_by_line.setdefault(call.lineno, (node.id, call))
 
         for site in pycallable.call_sites or []:
-            target = site.callee_signature
+            # Prefer the callsite's body-backfilled callee over Jedi's own
+            # callee_signature side channel: under cross-test parso/Jedi cache
+            # pressure that inference can silently degrade (full-suite-only
+            # loss of SDG summary/global stitching -- test_dataflow_sdg.py),
+            # while BodyNode.callee is the deterministic L2 path (Jedi filtered
+            # the same way, PLUS the defuse linker's fallback -- l2_callees.py).
+            # Only a resolved INTERNAL target counts (id_to_sig misses on an
+            # external/unresolved callee); falls through to callee_signature
+            # exactly as before whenever the body doesn't have an answer.
+            body_node = pycallable.body.get(f"{site.start_line}:{site.start_column}")
+            target = (id_to_sig.get(body_node.callee) if body_node else None) or site.callee_signature
             if not target:
                 continue
             if target in class_idx and target not in infos:

--- a/codeanalyzer/neo4j/project.py
+++ b/codeanalyzer/neo4j/project.py
@@ -435,6 +435,7 @@ def _project_config_uses(
             app_ref,
             ghost_ref,
             prune({"key": r.key, "reason": r.reason, "prov": list(r.prov) if r.prov else None}),
+            # _k=(key,reason) does not per-site discriminate the non-literal bucket (accepted prop-list ceiling).
             key=f"{r.key or ''}|{r.reason}",
         )
 

--- a/codeanalyzer/neo4j/project.py
+++ b/codeanalyzer/neo4j/project.py
@@ -105,6 +105,12 @@ def project(app: PyApplication, app_name: str, sig_to_id: dict,
     # full-depth-always regardless of -a.
     _project_artifacts(b, app, app_name, app_ref)
 
+    # config_use (#162): the resolved-read bridge (PyBodyNode from
+    # _project_program_graphs above) into the config-key subgraph
+    # (ConfigKey from _project_artifacts above), plus first-class unresolved
+    # reads.
+    _project_config_uses(b, app, app_ref, externals, sig_to_id)
+
     return b.finish()
 
 
@@ -390,6 +396,47 @@ def _project_artifacts(b: RowBuilder, app: PyApplication, app_name: str, app_ref
         if key not in seen:
             seen.add(key)
             b.edge("PY_UNRESOLVED_IMPORT", app_ref, ghost_ref, prune({"prov": u.prov}))
+
+
+def _project_config_uses(
+    b: RowBuilder, app: PyApplication, app_ref: NodeRef, externals: dict, sig_to_id: dict,
+) -> None:
+    """config_use (#162): PY_USES_CONFIG (`app.config_uses`) and
+    PY_READS_CONFIG_UNRESOLVED (`app.config_reads_unresolved`).
+
+    `PyConfigUseEdge.src`/`.dst` are already a GLOBAL ordinal id and a
+    ConfigKey id (both resolved upstream by `resolve_uses`), so — like
+    `param_in`/`param_out` — they address existing PyBodyNode/ConfigKey rows
+    directly with a plain :class:`NodeRef`; no defer-and-gate needed. Call
+    nodes enter a callable's `body` at L1 (before any config_use tier runs),
+    so the src PyBodyNode is always already projected by
+    `_project_program_graphs`, whatever level this ran at.
+
+    `PyConfigRead.callee` is already the full external `can://…/@external/…`
+    id (not a bare module name), so its ghost goes through `_call_endpoint`
+    (which looks it up in `externals` directly) rather than `_import_ghost`
+    (built for a bare imported name) — same inline node()+edge() shape
+    `PY_UNRESOLVED_IMPORT` uses. `_k` discriminates by (key, reason): the same
+    external callee (e.g. `os.getenv`) legitimately reads several distinct
+    undeclared/dynamic keys across a codebase, and without a discriminant a
+    plain endpoint-pair MERGE would collapse those onto one relationship.
+    """
+    for e in app.config_uses:
+        b.edge(
+            "PY_USES_CONFIG",
+            NodeRef("PyBodyNode", "id", e.src),
+            NodeRef("ConfigKey", "id", e.dst),
+            prune({"prov": list(e.prov) if e.prov else None}),
+        )
+    for r in app.config_reads_unresolved:
+        ghost_ref = _call_endpoint(b, r.callee, externals, sig_to_id)
+        b.edge(
+            "PY_READS_CONFIG_UNRESOLVED",
+            app_ref,
+            ghost_ref,
+            prune({"key": r.key, "reason": r.reason, "prov": list(r.prov) if r.prov else None}),
+            key=f"{r.key or ''}|{r.reason}",
+        )
 
 
 def _sym(can_id: str) -> NodeRef:

--- a/codeanalyzer/neo4j/schema.py
+++ b/codeanalyzer/neo4j/schema.py
@@ -291,6 +291,22 @@ REL_TYPES: List[RelType] = [
     RelType("LOCKS", ["Artifact"], ["Package"], {"version": "string"}),
     RelType("PY_PROVIDES", ["Package"], ["PyExternal"]),
     RelType("PY_UNRESOLVED_IMPORT", ["PyApplication"], ["PyExternal"], {"prov": "string[]"}),
+    # config_use (#162): the resolved-read bridge from a call site's body node
+    # to the PyConfigKey it reads. `src`/`dst` are already GLOBAL ordinal /
+    # ConfigKey ids (resolved upstream by `resolve_uses`), so no discriminant
+    # is needed -- one call site reads one key per edge.
+    RelType("PY_USES_CONFIG", ["PyBodyNode"], ["ConfigKey"], {"prov": "string[]"}),
+    # A detector-matched read that never closed on exactly one declared key --
+    # first-class per #162, PyApplication -> PyExternal ghost of the callee
+    # (mirrors PY_UNRESOLVED_IMPORT's shape). `_k` discriminates by (key,
+    # reason): the same external callee (e.g. `os.getenv`) legitimately reads
+    # several distinct undeclared/dynamic keys across a codebase -- without a
+    # discriminant a plain endpoint-pair MERGE would collapse those onto one
+    # relationship and silently drop every key but the last one SET.
+    RelType(
+        "PY_READS_CONFIG_UNRESOLVED", ["PyApplication"], ["PyExternal"],
+        {"key": "string", "reason": "string", "prov": "string[]", "_k": "string"},
+    ),
 ]
 
 

--- a/codeanalyzer/schema/py_schema.py
+++ b/codeanalyzer/schema/py_schema.py
@@ -520,6 +520,39 @@ class PyArtifact(BaseModel):
 
 
 @builder
+class PyConfigUseEdge(BaseModel):
+    """One resolved config read (#162): a detector-matched call's key
+    argument closed on exactly one string literal that matches a declared
+    ``PyConfigKey``. ``src`` is the call's GLOBAL ordinal id
+    (``<callable-id>@<local-id>``); ``dst`` is the matched ``PyConfigKey.id``
+    -- application scope, mirroring ``param_in`` (endpoints span callables/
+    artifacts). Superset-monotonic across levels, same additive contract as
+    the DDG's ``prov`` widening: literal (``-a 2``+) subset of +dataflow
+    (``-a 3``/``-a 4``)."""
+
+    src: str
+    dst: str
+    prov: List[Literal["literal", "dataflow"]] = []
+
+
+@builder
+class PyConfigRead(BaseModel):
+    """A detector-matched call whose key did not close on exactly one string
+    literal -- first-class so a config read nobody can trace is as visible
+    as one that resolves (#162). ``key`` is the decoded literal text only
+    when it IS a literal but matches no declared ``PyConfigKey``
+    (``reason="undefined-key"``); ``None`` for a key that never closed on a
+    literal at all (``reason="non-literal"``). ``prov`` lists every tier
+    that was attempted before giving up."""
+
+    site: str  # GLOBAL ordinal id
+    callee: str  # external id (can://.../@external/<module>/<name>)
+    key: Optional[str] = None
+    reason: Literal["non-literal", "undefined-key"]
+    prov: List[Literal["literal", "dataflow"]] = []
+
+
+@builder
 class PyDependency(BaseModel):
     """One declared third-party dependency, evidence-tagged via ``prov``."""
 
@@ -590,6 +623,10 @@ class PyApplication(BaseModel):
     # Interprocedural parameter-passing edges (formal↔actual); populated at L4.
     param_in: List[ParamEdge] = []
     param_out: List[ParamEdge] = []
+    # config_use (#162): PY_USES_CONFIG edges + first-class unresolved reads.
+    # Literal tier from L2; dataflow tiers widen the set at L3/L4 (additive).
+    config_uses: List[PyConfigUseEdge] = []
+    config_reads_unresolved: List[PyConfigRead] = []
 
 
 @builder

--- a/codeanalyzer/schema/py_schema.py
+++ b/codeanalyzer/schema/py_schema.py
@@ -306,6 +306,17 @@ class PyCallArgument(BaseModel):
 
     ast_kind: str
     inferred_type: Optional[str] = None
+    # Literal capture (#162): populated only for an `ast.Constant` argument
+    # whose value is str/int/float/bool/None, JSON-encoded (`json.dumps`) --
+    # decode with `json.loads` to recover the Python constant. `None` for
+    # every non-constant argument (and for a Constant of another type, e.g.
+    # bytes/complex/Ellipsis).
+    value: Optional[str] = None
+    # Bare-identifier capture (#162): the `id` of an `ast.Name` argument
+    # (e.g. `f(KEY)` -> `"KEY"`) -- ships alongside `value` as the dataflow
+    # tier's join point back to the variable's own definitions. `None` for
+    # every other argument shape.
+    name: Optional[str] = None
 
 
 # BodyNode.arguments forward-references PyCallArgument (defined later);

--- a/codeanalyzer/syntactic_analysis/symbol_table_builder.py
+++ b/codeanalyzer/syntactic_analysis/symbol_table_builder.py
@@ -1,5 +1,6 @@
 import ast
 import hashlib
+import json
 import os
 import tokenize
 from ast import AST, ClassDef
@@ -786,6 +787,16 @@ class SymbolTableBuilder:
                 PyCallArgument(
                     ast_kind=type(arg).__name__,
                     inferred_type=self._infer_type(script, arg.lineno, arg.col_offset),
+                    # Literal/name capture (#162): value JSON-encoded for a
+                    # Constant of a JSON-safe type; name for a bare Name --
+                    # never both, per the AST shapes involved.
+                    value=(
+                        json.dumps(arg.value)
+                        if isinstance(arg, ast.Constant)
+                        and isinstance(arg.value, (str, int, float, bool, type(None)))
+                        else None
+                    ),
+                    name=arg.id if isinstance(arg, ast.Name) else None,
                 )
                 for arg in node.args
             ]

--- a/docs/design/plans/2026-08-28-config-use-edge.md
+++ b/docs/design/plans/2026-08-28-config-use-edge.md
@@ -1,0 +1,50 @@
+# config_use Edge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Mint `PY_USES_CONFIG` edges (three deterministic tiers) plus first-class unresolved config reads (closes #162).
+
+**Architecture:** `PyCallArgument` gains literal capture (`value`) and bare-name capture (`name`); a shipped detector table (`codeanalyzer/artifacts/config_use_rules.yml`) identifies config-reading call sites; `codeanalyzer/artifacts/config_use.py` resolves keys per tier (literal at L2, DDG single-literal closure at L3, cross-procedure closure at L4) against `PyArtifact.config_keys`, emitting `application.config_uses` + `application.config_reads_unresolved`; Neo4j projects `PY_USES_CONFIG` and `PY_READS_CONFIG_UNRESOLVED`.
+
+**Tech Stack:** existing symbol-table/DDG/call-graph substrates; yaml (in-tree); json for value encoding.
+
+**Spec:** `docs/design/specs/2026-08-28-config-use-edge-design.md`
+
+## Global Constraints
+
+- No AI attribution. Conventional Commits. Pydantic v1 compat (no v2-only idioms outside compat helpers).
+- Determinism: no tier ever guesses. A chain not closing on exactly one string literal (identical duplicates count as one) is unresolved. Sorted iteration everywhere; two identical runs byte-identical.
+- Superset-monotonicity: `config_uses` at `-a 2` ⊆ `-a 3` ⊆ `-a 4`; CI-gate test required. `PyCallArgument.value`/`name` are L1 data.
+- prov vocabulary exactly: `literal`, `dataflow`. `reason` vocabulary exactly: `non-literal`, `undefined-key`.
+- `value` is JSON-encoded (`json.dumps`) for any `ast.Constant`; `name` is the bare identifier for `ast.Name` args; both `None` otherwise.
+- Namespace preference per detector entry; first namespace with ≥1 match wins; all matches in that namespace get edges.
+- Neutral ConfigKey untouched; the new edge and unresolved rel are `PY_`-prefixed (this analyzer's claim).
+
+---
+
+### Task 1: Argument capture (L1)
+
+**Files:** Modify `codeanalyzer/schema/py_schema.py` (PyCallArgument: `value: Optional[str] = None`, `name: Optional[str] = None`, field comments documenting json.loads decode + bare-Name capture), `codeanalyzer/syntactic_analysis/symbol_table_builder.py:786` (populate both: `value=json.dumps(arg.value)` when `isinstance(arg, ast.Constant)` and the value is str/int/float/bool/None; `name=arg.id` when `isinstance(arg, ast.Name)`). Spec amendment: add one sentence to the spec's Locked decision 1 noting `name` (bare-identifier capture) ships alongside `value` — the dataflow tier's join point (controller ruling, recorded in ledger). Test `test/test_call_argument_capture.py`: `f("DB_HOST")` → value `'"DB_HOST"'`; `f(3)` → `'3'`; `f(True)`/`f(None)` → `'true'`/`'null'`; `f(KEY)` → value None, name `"KEY"`; `f(obj.attr)` → both None; L1 round-trip through compat helpers; old payloads default None.
+Commit: `feat(schema): literal and name capture on call arguments`
+
+### Task 2: Detector table + literal tier + unresolved records
+
+**Files:** Create `codeanalyzer/artifacts/config_use_rules.yml` (entries: `module`, `callable`, `key_arg` int position, `kwarg` optional name, `namespaces` ordered list — v1 set per spec §3 incl. os.environ.get/os.getenv arg 0 [env]; dotenv.get_key arg 1 [env]; configparser get/getint/getfloat/getboolean arg 1 kwarg "option" [ini, properties]), `codeanalyzer/artifacts/config_use.py` (loader with schema validation; `detect_config_reads(app) -> List[_Read]` scanning body call nodes whose `callee` matches a rule's external id suffix `@external/<module>/<callable>` — also match dotted receiver forms the linker emits; `_Read` = site global id, callee id, rule, key literal via value-decode, key name via name field; `resolve_uses(reads, app, tier_fns) -> (List[PyConfigUseEdge], List[PyConfigRead])` — literal tier: decoded str key → ConfigKey match per namespace preference (env exact `key ==`; ini/properties suffix `key.endswith("." + literal) or key == literal`); build edges prov ["literal"]; non-literal or no-match → PyConfigRead with reason), models in `codeanalyzer/schema/py_schema.py` (`PyConfigUseEdge {src, dst, prov}`, `PyConfigRead {site, callee, key: Optional, reason, prov}`, application fields `config_uses`/`config_reads_unresolved` default []), core wiring in the `>= 2` block after callee backfill. Subscript caveat: verify whether `os.environ["X"]` produces a call body node; document the finding in the module docstring; if not lowered, note as recorded gap (no new mechanism).
+Test `test/test_config_use_literal.py`: fixture-in-tmp project with `.env` (DB_HOST=x) + code `os.getenv("DB_HOST")` → one edge, prov ["literal"]; `os.getenv("MISSING")` → unresolved reason "undefined-key"; `os.getenv(kvar)` → reason "non-literal" at -a 2; namespace preference (ini option matching section.option suffix); determinism two-runs.
+Commit: `feat(artifacts): config-use detector table and literal tier`
+
+### Task 3: Dataflow tiers
+
+**Files:** Extend `codeanalyzer/artifacts/config_use.py` (+ wiring in core L3/L4 blocks). Intra (L3): for each unresolved read with `name` set, find its callable's DDG edges into the call node's local id with var == name; for each def endpoint, slice the module source at the def node's span and `ast.parse` the statement — accept exactly `Name = <str Constant>` single-target Assign; all reaching defs must yield one identical literal → resolve (prov ["dataflow"]), else stays unresolved. Interproc (L4): unresolved read whose `name` is a parameter of its enclosing callable → all call sites targeting that callable (via call_graph + body callee ids): each site's PyCallArgument at the param's position/kwarg must be the same str literal (value field), OR itself close intra-procedurally in ITS caller (one recursion level, visited-set guarded); all sites agree → resolve, else unresolved. Reads resolved at a lower tier are never recomputed (additive; monotonicity by construction — L3 run = literal + intra; L4 run = literal + intra + interproc).
+Test `test/test_config_use_dataflow.py`: `KEY = "DB_HOST"; os.getenv(KEY)` resolves at -a 3 not -a 2; two differing defs → unresolved at all levels; loop-carried (`for k in [...]: os.getenv(k)`) unresolved; `def read(name): return os.getenv(name)` + single call `read("DB_HOST")` resolves at -a 4 not -a 3; two call sites with different literals → unresolved; monotonicity assert `-a 2 ⊆ -a 3 ⊆ -a 4` on edge sets.
+Commit: `feat(artifacts): dataflow tiers for config-use resolution`
+
+### Task 4: Neo4j projection
+
+**Files:** `codeanalyzer/neo4j/schema.py` (RelTypes: `PY_USES_CONFIG` [PyBodyNode]→[ConfigKey] props `{prov: "string[]"}`; `PY_READS_CONFIG_UNRESOLVED` [PyApplication]→[PyExternal] props `{key: "string", reason: "string", prov: "string[]"}`), `codeanalyzer/neo4j/project.py` (emit both from app.config_uses/config_reads_unresolved — src PyBodyNode by global id, dst ConfigKey by id; unresolved: callee external ghost merged like PY_UNRESOLVED_IMPORT does), regenerate `schema.neo4j.json`, extend `test/sample_graph_app.py` so both rels are exercised (its pyproject config keys + an os.getenv literal read in the sample source). Test `test/test_neo4j_config_use.py` mirroring test_neo4j_config_keys.py idioms.
+Commit: `feat(neo4j): PY_USES_CONFIG and unresolved-read projection`
+
+### Task 5: e2e + skill + docs
+
+**Files:** manifests_app fixture: add `pkg/config_reader.py` covering all five DoD shapes (direct literal hitting `.env`'s DB-ish key, variable-closing, param-passed via helper, multi-def unresolved, undefined-key read); extend `test/test_artifacts_end_to_end.py` (edge set exact at -a 4; unresolved reasons exact; determinism); CHANGELOG Unreleased line; README Output-shape sentence; on the design/skill-neo4j-exhaustive branch DO NOTHING (skill update tracked there per DoD — instead append a line to the ledger). Full suite, exact counts.
+Commit: `test(artifacts): config-use e2e coverage; docs`

--- a/docs/design/specs/2026-08-28-config-use-edge-design.md
+++ b/docs/design/specs/2026-08-28-config-use-edge-design.md
@@ -1,0 +1,112 @@
+# config_use: The PY_USES_CONFIG Edge
+
+**Date:** 2026-08-28
+**Status:** Approved (design dialogue in-session)
+**Scope:** codeanalyzer-python, schema v2 additive; closes #162
+**Builds on:** ConfigKey family (`2026-08-28-config-key-family-design.md`, PR #163)
+
+## Problem
+
+The artifact layer has both shores: config files define keys
+(`(:Artifact)-[:DEFINES_CONFIG]->(:ConfigKey)`) and code calls out through
+externals. The bridge — *which statement reads which key* — is this unit:
+
+```
+(:PyBodyNode)-[:PY_USES_CONFIG]->(:ConfigKey)
+```
+
+Py-prefixed by the settled rule: reading a key is this analyzer's claim about
+Python code; the key node stays neutral. Sibling analyzers mint their own
+(`TS_USES_CONFIG`, …) — recorded on epic codellm-devkit/.github#45 as a
+standard feature of the layer.
+
+## Locked decisions
+
+1. **`PyCallArgument.value: Optional[str]`** — any `ast.Constant`
+   **JSON-encoded** (`'"DB_HOST"'`, `'3'`, `'true'`, `'null'`); non-constant
+   arguments stay `None`. L1 body data, additive, emitted for every call
+   argument. Decoding rule documented on the field: `json.loads` yields the
+   Python constant (str/int/float/bool/None).
+2. **Detection is level-graded, all in scope** (per the amended #162):
+   - **Literal tier** (`-a 2`+, `prov: ["literal"]`): the call node's callee
+     resolves to a detector-listed external and the key argument is a string
+     literal (`value` decodes to `str`).
+   - **Dataflow tier intra** (`-a 3`+, `prov: ["dataflow"]`): non-literal key
+     whose DDG def-use chain closes over exactly one string-literal
+     definition — constant propagation over the analyzer's own deterministic
+     DDG.
+   - **Dataflow tier interprocedural** (`-a 4`, same `prov`): the chain
+     extends through `param_in` — a formal whose every reaching actual is
+     the same string literal resolves reads inside the callee.
+   - Chains not closing on exactly one literal stay **unresolved** — never
+     guessed. Superset-monotonic across levels (literal ⊆ +intra ⊆
+     +interproc), same additive contract as the DDG's prov widening.
+3. **Detector ruleset is a shipped table**, `artifacts/config_use_rules.yml`
+   (same mechanism family as `entrypoints/rules.yml`): entries declare the
+   external target (module + callable name), which argument is the key
+   (position or kwarg name), and the **namespace preference order** for
+   resolution. Shipped v1 set:
+   - `os.environ.__getitem__` / `os.environ.get` / `os.getenv` → arg 0,
+     namespaces `[env]`
+   - `dotenv.get_key` → arg 1 (key), `[env]`; `dotenv.dotenv_values` — no key
+     arg, not an edge source
+   - `configparser` `get`/`getint`/`getfloat`/`getboolean` → kwarg/pos
+     `option` (arg 1), namespaces `[ini, properties]`
+   No user-extension flag yet (matches artifact rules posture).
+4. **Resolution**: literal key text → ConfigKey nodes matched by `key ==
+   literal` (env namespace: exact; ini: match the `section.option` suffix —
+   the option name matches the last dotted segment) within the detector's
+   namespace preference order; first namespace with ≥1 match wins; ALL
+   matching keys in that namespace get edges (a key defined in `.env` and
+   `.env.prod` yields two edges — both true).
+5. **Unmatched reads are first-class**: `application.config_reads_unresolved:
+   List[PyConfigRead]` — every detector hit whose key is statically unknown
+   (no literal, chain didn't close) or whose literal matches no ConfigKey
+   (reads config nobody defines — the hygiene signal). Fields: `site`
+   (GLOBAL ordinal id), `callee` (external id), `key` (Optional — present
+   when literal known but undefined), `reason` (`"non-literal"` \|
+   `"undefined-key"`), `prov`.
+6. **JSON placement**: `application.config_uses: List[PyConfigUseEdge]`
+   (`src` GLOBAL ordinal, `dst` ConfigKey id, `prov`) — application scope,
+   mirroring `param_in` (endpoints span callables/artifacts).
+
+## Neo4j
+
+`PY_USES_CONFIG` RelType (PyBodyNode→ConfigKey, props `prov: string[]`);
+`config_reads_unresolved` projected as `PY_READS_CONFIG_UNRESOLVED`
+(PyApplication→PyExternal ghost of the callee, props `key`, `reason`,
+`prov`) — mirrors `PY_UNRESOLVED_IMPORT`'s shape. `SCHEMA_VERSION` stays
+2.0.0.
+
+## Level gating
+
+`PyCallArgument.value` emitted at L1 (body build). Edges: literal tier
+computed in the L2 block (needs resolved callees); dataflow-intra in the L3
+block (needs DDG); interproc in the L4 block (needs param_in). Monotonicity
+gate extended to `config_uses`.
+
+## Caveats
+
+- `os.environ["X"]` is subscript, not a call — the literal tier reads it via
+  the body node's call lowering only if the symbol table lowers
+  `__getitem__`; if it does not, v1 detects `.get`/`getenv` forms and the
+  subscript form is a recorded gap (verify during implementation; if absent,
+  add a targeted subscript detector on the same table entry rather than a
+  new mechanism).
+- Multi-literal closure (a chain closing on two *identical* literals) counts
+  as closed; differing literals = unresolved.
+- configparser section context is not tracked (which `[section]` the option
+  belongs to at the read site is dynamic); suffix matching may over-match
+  across sections — recorded, acceptable v1 (prov marks the tier, consumers
+  can threshold).
+
+## Definition of done
+
+- [ ] `PyCallArgument.value` JSON-encoded constants at L1, round-trip tested.
+- [ ] Literal-tier edges at `-a 2`; dataflow-intra at `-a 3`; interproc at
+  `-a 4`; superset-monotonic (gate test).
+- [ ] Fixture: direct literal, variable-closing-to-literal, param-passed
+  literal, multi-def unresolved, loop-carried unresolved, undefined-key read.
+- [ ] `config_reads_unresolved` populated with reasons; both projections;
+  determinism (two identical runs); full suite green.
+- [ ] Skill vocabulary/analyses updated on the #161 line (bridge queries).

--- a/docs/design/specs/2026-08-28-config-use-edge-design.md
+++ b/docs/design/specs/2026-08-28-config-use-edge-design.md
@@ -87,7 +87,12 @@ standard feature of the layer.
 `PyCallArgument.value` emitted at L1 (body build). Edges: literal tier
 computed in the L2 block (needs resolved callees); dataflow-intra in the L3
 block (needs DDG); interproc in the L4 block (needs param_in). Monotonicity
-gate extended to `config_uses`.
+gate extended to `config_uses`. `config_reads_unresolved` is not itself
+monotonic -- it deliberately shrinks as levels rise (a record a higher tier
+resolves migrates into `config_uses` and drops out of the unresolved list);
+the monotonicity contract binds the edge set, and the unresolved list is
+its complement, in the same sanctioned-refinement family as `callee:
+null→id`.
 
 ## Caveats
 

--- a/docs/design/specs/2026-08-28-config-use-edge-design.md
+++ b/docs/design/specs/2026-08-28-config-use-edge-design.md
@@ -26,7 +26,11 @@ standard feature of the layer.
    **JSON-encoded** (`'"DB_HOST"'`, `'3'`, `'true'`, `'null'`); non-constant
    arguments stay `None`. L1 body data, additive, emitted for every call
    argument. Decoding rule documented on the field: `json.loads` yields the
-   Python constant (str/int/float/bool/None).
+   Python constant (str/int/float/bool/None). `PyCallArgument.name:
+   Optional[str]` ships alongside `value` — the bare identifier of an
+   `ast.Name` argument (`None` otherwise), added because the dataflow tier
+   has no other join point back to the variable's own definitions
+   (controller ruling; amends this decision).
 2. **Detection is level-graded, all in scope** (per the amended #162):
    - **Literal tier** (`-a 2`+, `prov: ["literal"]`): the call node's callee
      resolves to a detector-listed external and the key argument is a string

--- a/docs/design/specs/2026-08-28-config-use-edge-design.md
+++ b/docs/design/specs/2026-08-28-config-use-edge-design.md
@@ -108,6 +108,10 @@ null→id`.
   belongs to at the read site is dynamic); suffix matching may over-match
   across sections — recorded, acceptable v1 (prov marks the tier, consumers
   can threshold).
+- Kwarg-passed keys (`cp.get(section, option="x")`) land in non-literal
+  unresolved: `BodyNode.arguments` only ever holds positional arguments
+  (`symbol_table_builder.py` walks `node.args`, never `node.keywords`), so a
+  kwarg-only call has no substrate to read the key from.
 
 ## Definition of done
 

--- a/schema.neo4j.json
+++ b/schema.neo4j.json
@@ -465,6 +465,33 @@
       "properties": {
         "prov": "string[]"
       }
+    },
+    {
+      "type": "PY_USES_CONFIG",
+      "from": [
+        "PyBodyNode"
+      ],
+      "to": [
+        "ConfigKey"
+      ],
+      "properties": {
+        "prov": "string[]"
+      }
+    },
+    {
+      "type": "PY_READS_CONFIG_UNRESOLVED",
+      "from": [
+        "PyApplication"
+      ],
+      "to": [
+        "PyExternal"
+      ],
+      "properties": {
+        "key": "string",
+        "reason": "string",
+        "prov": "string[]",
+        "_k": "string"
+      }
     }
   ],
   "constraints": [

--- a/test/fixtures/whole_applications/manifests_app/pkg/config_reader.py
+++ b/test/fixtures/whole_applications/manifests_app/pkg/config_reader.py
@@ -1,0 +1,40 @@
+"""Config-use e2e fixture for all five detection shapes (#162 Task 5)."""
+import os
+
+
+# Shape 1: Direct literal, reads DATABASE_URL from .env (resolves at -a 2)
+def get_database_url():
+    return os.getenv("DATABASE_URL")
+
+
+# Shape 2: Variable-closing to literal, reads API_KEY from .env
+# Resolves only at -a 3+ (DDG single-literal closure)
+def get_api_key():
+    key_name = "API_KEY"
+    return os.getenv(key_name)
+
+
+# Shape 3: Param-passed via local helper, reads SECRET_API_TOKEN from .env
+# Resolves only at -a 4 (interprocedural parameter-passing)
+def _read_config(name):
+    return os.getenv(name)
+
+
+def get_secret_token():
+    return _read_config("SECRET_API_TOKEN")
+
+
+# Shape 4: Multi-def unresolved (two different literals on branches)
+# Should stay unresolved at all levels (reason: "non-literal")
+def get_config_multi_def(use_debug):
+    if use_debug:
+        var = "DEBUG"
+    else:
+        var = "FLASK_ENV"
+    return os.getenv(var)
+
+
+# Shape 5: Undefined-key read
+# Should appear in config_reads_unresolved with reason: "undefined-key"
+def get_missing_config():
+    return os.getenv("NOT_DEFINED_ANYWHERE")

--- a/test/sample_graph_app.py
+++ b/test/sample_graph_app.py
@@ -7,7 +7,11 @@ graph with a resolved edge and a ghost edge, each callable's CPG
 interprocedural ``param_in``/``param_out``/``summary`` param-passing overlay plus
 the points-to ``ddg`` delta. Also carries the artifact/dependency subgraph
 (Task 6): a manifest + lock artifact and a locked, import-providing dependency,
-plus the manifest's own flattened config keys (#152).
+plus the manifest's own flattened config keys (#152), and a hand-built
+``config_uses``/``config_reads_unresolved`` pair (#162 Task 4) addressing a
+real ``os.getenv`` call site in the sample source -- config_use's own
+detector/resolver pipeline is unit-tested elsewhere (test_config_use_*.py);
+this fixture only needs one authentic GLOBAL ordinal id per edge kind.
 
 The symbol table is built from a real (temporary) source file so
 ``build_function_pdgs`` can recover each callable's AST; ``assign_ids`` +
@@ -23,6 +27,7 @@ that ``assign_ids`` produced.
 """
 from __future__ import annotations
 
+import json
 import tempfile
 from pathlib import Path
 from typing import Dict, Tuple
@@ -44,7 +49,7 @@ from codeanalyzer.schema.ids import artifact_id
 from codeanalyzer.schema.l1_body import populate_l1_body
 from codeanalyzer.schema.l2_callees import backfill_callees
 from codeanalyzer.schema.py_schema import (
-    PyArtifact, PyCallEdge, PyDependency, PyImportBinding,
+    PyArtifact, PyCallEdge, PyConfigRead, PyConfigUseEdge, PyDependency, PyImportBinding,
 )
 from codeanalyzer.semantic_analysis.call_graph import (
     iter_callables_in_symbol_table,
@@ -95,6 +100,12 @@ def helper(flag):
 def build(x):
     y = x
     return y
+
+
+def read_config():
+    host = os.getenv("DB_HOST")
+    missing = os.getenv("MISSING")
+    return host, missing
 '''
 
 
@@ -200,6 +211,40 @@ def make_sample_app() -> Tuple[PyApplication, Dict[str, str]]:
     # their resolved `callee`. Without it PY_RESOLVES_TO never fires, since #120
     # sources that edge from the body node rather than from `call_sites[]`.
     backfill_callees(app, sig_to_id)
+
+    # config_use (#162 Task 4): PY_USES_CONFIG / PY_READS_CONFIG_UNRESOLVED
+    # exercise, guarded by
+    # test_all_catalog_node_kinds_and_relationships_are_exercised. Hand-built
+    # like call_graph/artifacts above -- addresses `read_config`'s two real
+    # `os.getenv` call sites (so the projector has authentic GLOBAL ordinal
+    # ids) against the manifest's own flattened config key from Task 6 above.
+    getenv_ext_id = "can://python/sample-app/@external/os/getenv"
+    app.external_symbols[getenv_ext_id] = PyExternalSymbol(
+        id=getenv_ext_id, name="getenv", module="os"
+    )
+    sig_to_id["os.getenv"] = getenv_ext_id
+    read_config_fn = app.symbol_table["service.py"].functions["read_config"]
+    db_host_key = next(
+        k for k, v in read_config_fn.body.items()
+        if v.kind == "call" and v.arguments and v.arguments[0].value == json.dumps("DB_HOST")
+    )
+    missing_key = next(
+        k for k, v in read_config_fn.body.items()
+        if v.kind == "call" and v.arguments and v.arguments[0].value == json.dumps("MISSING")
+    )
+    pyproject_key = app.artifacts["pyproject.toml"].config_keys[0]
+    app.config_uses = [
+        PyConfigUseEdge(
+            src=f"{read_config_fn.id}@{db_host_key}", dst=pyproject_key.id, prov=["literal"],
+        ),
+    ]
+    app.config_reads_unresolved = [
+        PyConfigRead(
+            site=f"{read_config_fn.id}@{missing_key}", callee=getenv_ext_id,
+            key="MISSING", reason="undefined-key", prov=["literal"],
+        ),
+    ]
+
     syntactic_infos, _func_asts = build_function_pdgs(
         app, k=3, oracle_factory=lambda c, fast: SyntacticOracle()
     )

--- a/test/test_artifacts_end_to_end.py
+++ b/test/test_artifacts_end_to_end.py
@@ -221,96 +221,64 @@ def test_config_keys_extraction_full(tmp_path):
     assert app.artifacts["app.properties"].extraction == "full"
 
 
+def _id_suffix(id_: str) -> str:
+    """The trailing `<callable-sig>@<local-id>` (or `@key/<name>`) segment of
+    a `can://` id -- past the app-name-qualified prefix every assertion
+    below would otherwise have to repeat verbatim."""
+    return id_.rsplit("/", 1)[-1]
+
+
 def test_config_uses_full(tmp_path):
-    """Verify config-use edges at -a 4: all five fixture shapes (#162 Task 5)."""
+    """Verify config-use edges at -a 4: all five fixture shapes (#162 Task 5).
+
+    Exact-set assertions (the plan's "exact", not a `>=` lower bound): every
+    `config_uses` edge as `(src-suffix, dst-key, prov)` and every
+    `config_reads_unresolved` record as `(site-suffix, reason, key)`, pinned
+    to ground truth read directly off this fixture (empirically re-verified
+    against the dataflow-tier fixes landed alongside this test -- none of
+    those fixes' shapes (aliasing, conditional shadowing, module-scope
+    callers) occur in this fixture, so the counts are unchanged from the
+    pre-fix reviewer probe: 3 resolved, 2 unresolved at -a 4).
+    """
     app = Codeanalyzer(AnalysisOptions(
         input=FIXTURE, analysis_level=4, no_venv=True, cache_dir=tmp_path / "config_uses",
     )).analyze().application
 
-    # Find the config_reader module in the symbol table
-    config_reader_mod = None
-    for mod in app.symbol_table.values():
-        if "config_reader" in mod.id:
-            config_reader_mod = mod
-            break
-    assert config_reader_mod is not None, "pkg/config_reader.py not in symbol table"
-
-    # Expected edges at -a 4 (all three tiers resolved):
     # 1. Direct literal: get_database_url() -> os.getenv("DATABASE_URL")
     # 2. Variable-closing: get_api_key() -> os.getenv(key_name="API_KEY")
     # 3. Param-passed: get_secret_token() -> _read_config("SECRET_API_TOKEN")
+    #    (site is the read INSIDE _read_config, not get_secret_token's call)
     # 4. Multi-def unresolved: get_config_multi_def() -> unresolved (two defs)
     # 5. Undefined-key: get_missing_config() -> unresolved (key not in .env)
+    uses = {(_id_suffix(e.src), _id_suffix(e.dst), tuple(e.prov)) for e in app.config_uses}
+    assert uses == {
+        ("get_database_url()@7:11", "DATABASE_URL", ("literal",)),
+        ("get_api_key()@14:11", "API_KEY", ("dataflow",)),
+        ("_read_config(name)@20:11", "SECRET_API_TOKEN", ("dataflow",)),
+    }
 
-    # Collect all config_uses edges
-    uses = app.config_uses
-    uses_by_dst = {}
-    for e in uses:
-        if e.dst not in uses_by_dst:
-            uses_by_dst[e.dst] = []
-        uses_by_dst[e.dst].append(e)
-
-    # Collect all config_reads_unresolved
-    unresolved = app.config_reads_unresolved
-    unresolved_by_reason = {}
-    for r in unresolved:
-        if r.reason not in unresolved_by_reason:
-            unresolved_by_reason[r.reason] = []
-        unresolved_by_reason[r.reason].append(r)
-
-    # Expected resolved keys from .env (env namespace):
-    # DATABASE_URL (literal), API_KEY (dataflow), SECRET_API_TOKEN (interproc)
-    expected_resolved_keys = {"DATABASE_URL", "API_KEY", "SECRET_API_TOKEN"}
-    actual_resolved_keys = set()
-    for src, edges in uses_by_dst.items():
-        if "/@external/" not in src:  # ConfigKey ids don't have /@external/
-            # Extract the key name from the ConfigKey id
-            # ConfigKey id format: can://python/<app>/<namespace>/<key>
-            parts = src.split("/")
-            if len(parts) > 0:
-                key_name = parts[-1]
-                actual_resolved_keys.add(key_name)
-
-    assert actual_resolved_keys >= expected_resolved_keys, \
-        f"Expected at least {expected_resolved_keys}, got {actual_resolved_keys}"
-
-    # Unresolved reads:
-    # Shape 4: multi-def (reason: non-literal)
-    # Shape 5: undefined-key (reason: undefined-key)
-    assert "non-literal" in unresolved_by_reason, \
-        f"Expected 'non-literal' unresolved, got reasons: {list(unresolved_by_reason.keys())}"
-    assert "undefined-key" in unresolved_by_reason, \
-        f"Expected 'undefined-key' unresolved, got reasons: {list(unresolved_by_reason.keys())}"
-
-    # Verify that undefined-key has a key value and non-literal does not
-    for r in unresolved_by_reason.get("undefined-key", []):
-        assert r.key == "NOT_DEFINED_ANYWHERE", \
-            f"Expected key 'NOT_DEFINED_ANYWHERE', got {r.key}"
-
-    for r in unresolved_by_reason.get("non-literal", []):
-        # Non-literal reasons should have no key (or key is None)
-        assert r.key is None, f"Expected key=None for non-literal, got {r.key}"
+    unresolved = {(_id_suffix(r.site), r.reason, r.key) for r in app.config_reads_unresolved}
+    assert unresolved == {
+        ("get_config_multi_def(use_debug)@34:11", "non-literal", None),
+        ("get_missing_config()@40:11", "undefined-key", "NOT_DEFINED_ANYWHERE"),
+    }
 
 
 def test_config_uses_tier_visibility(tmp_path):
-    """Verify config-use edges only appear at appropriate levels (#162)."""
-    # Literal tier visible at -a 2+
-    app_l2 = Codeanalyzer(AnalysisOptions(
-        input=FIXTURE, analysis_level=2, no_venv=True, cache_dir=tmp_path / "tier_l2",
-    )).analyze().application
-    uses_l2 = {e.dst for e in app_l2.config_uses}
+    """Verify config-use edges only appear at their appropriate tier (#162):
+    monotonic growth AND that each tier's own shape is genuinely gated, not
+    just implied by an accidental subset relationship (a subset check alone
+    would pass even if every edge resolved at -a 2 and later tiers added
+    nothing) -- the variable-closing key must be invisible before -a 3, and
+    the param-passed key invisible before -a 4."""
+    def keys_at(level):
+        app = Codeanalyzer(AnalysisOptions(
+            input=FIXTURE, analysis_level=level, no_venv=True,
+            cache_dir=tmp_path / f"tier_l{level}",
+        )).analyze().application
+        return {_id_suffix(e.dst) for e in app.config_uses}
 
-    # Variable-closing visible at -a 3+
-    app_l3 = Codeanalyzer(AnalysisOptions(
-        input=FIXTURE, analysis_level=3, no_venv=True, cache_dir=tmp_path / "tier_l3",
-    )).analyze().application
-    uses_l3 = {e.dst for e in app_l3.config_uses}
-
-    # Interproc visible at -a 4
-    app_l4 = Codeanalyzer(AnalysisOptions(
-        input=FIXTURE, analysis_level=4, no_venv=True, cache_dir=tmp_path / "tier_l4",
-    )).analyze().application
-    uses_l4 = {e.dst for e in app_l4.config_uses}
+    uses_l2, uses_l3, uses_l4 = keys_at(2), keys_at(3), keys_at(4)
 
     # Monotonicity: L2 ⊆ L3 ⊆ L4
     assert uses_l2 <= uses_l3, \
@@ -318,38 +286,26 @@ def test_config_uses_tier_visibility(tmp_path):
     assert uses_l3 <= uses_l4, \
         f"L3 edges should be subset of L4: {uses_l3 - uses_l4} in L3 but not L4"
 
+    # Variable-closing (API_KEY): absent before the intra tier exists.
+    assert "API_KEY" not in uses_l2
+    assert "API_KEY" in uses_l3
+
+    # Param-passed (SECRET_API_TOKEN): absent before the interproc tier exists.
+    assert "SECRET_API_TOKEN" not in uses_l3
+    assert "SECRET_API_TOKEN" in uses_l4
+
 
 def test_config_uses_determinism(tmp_path):
-    """Verify config-use edges are deterministic across two identical runs."""
-    import json
+    """Verify config-use edges are deterministic across two identical runs.
 
+    Raw `model_dump_json` comparison, no manual re-sort: `resolve_uses`
+    already sorts both `config_uses` and `config_reads_unresolved` before
+    returning them, so the emitted lists are byte-identical across runs
+    without reconstructing/sorting fields here (L1)."""
     app1 = Codeanalyzer(AnalysisOptions(
         input=FIXTURE, analysis_level=4, no_venv=True, cache_dir=tmp_path / "det1",
     )).analyze().application
     app2 = Codeanalyzer(AnalysisOptions(
         input=FIXTURE, analysis_level=4, no_venv=True, cache_dir=tmp_path / "det2",
     )).analyze().application
-
-    # Serialize and compare config_uses
-    uses1 = json.dumps(
-        [{"src": e.src, "dst": e.dst, "prov": sorted(e.prov)} for e in sorted(app1.config_uses, key=lambda x: (x.src, x.dst))],
-        sort_keys=True,
-    )
-    uses2 = json.dumps(
-        [{"src": e.src, "dst": e.dst, "prov": sorted(e.prov)} for e in sorted(app2.config_uses, key=lambda x: (x.src, x.dst))],
-        sort_keys=True,
-    )
-    assert uses1 == uses2, "config_uses differ between runs"
-
-    # Serialize and compare config_reads_unresolved
-    unres1 = json.dumps(
-        [{"site": r.site, "callee": r.callee, "key": r.key, "reason": r.reason, "prov": sorted(r.prov)}
-         for r in sorted(app1.config_reads_unresolved, key=lambda x: (x.site, x.reason))],
-        sort_keys=True,
-    )
-    unres2 = json.dumps(
-        [{"site": r.site, "callee": r.callee, "key": r.key, "reason": r.reason, "prov": sorted(r.prov)}
-         for r in sorted(app2.config_reads_unresolved, key=lambda x: (x.site, x.reason))],
-        sort_keys=True,
-    )
-    assert unres1 == unres2, "config_reads_unresolved differ between runs"
+    assert model_dump_json(app1) == model_dump_json(app2)

--- a/test/test_artifacts_end_to_end.py
+++ b/test/test_artifacts_end_to_end.py
@@ -219,3 +219,137 @@ def test_config_keys_extraction_full(tmp_path):
     assert app.artifacts[".env"].extraction == "full"
     assert app.artifacts["config/settings.yml"].extraction == "full"
     assert app.artifacts["app.properties"].extraction == "full"
+
+
+def test_config_uses_full(tmp_path):
+    """Verify config-use edges at -a 4: all five fixture shapes (#162 Task 5)."""
+    app = Codeanalyzer(AnalysisOptions(
+        input=FIXTURE, analysis_level=4, no_venv=True, cache_dir=tmp_path / "config_uses",
+    )).analyze().application
+
+    # Find the config_reader module in the symbol table
+    config_reader_mod = None
+    for mod in app.symbol_table.values():
+        if "config_reader" in mod.id:
+            config_reader_mod = mod
+            break
+    assert config_reader_mod is not None, "pkg/config_reader.py not in symbol table"
+
+    # Expected edges at -a 4 (all three tiers resolved):
+    # 1. Direct literal: get_database_url() -> os.getenv("DATABASE_URL")
+    # 2. Variable-closing: get_api_key() -> os.getenv(key_name="API_KEY")
+    # 3. Param-passed: get_secret_token() -> _read_config("SECRET_API_TOKEN")
+    # 4. Multi-def unresolved: get_config_multi_def() -> unresolved (two defs)
+    # 5. Undefined-key: get_missing_config() -> unresolved (key not in .env)
+
+    # Collect all config_uses edges
+    uses = app.config_uses
+    uses_by_dst = {}
+    for e in uses:
+        if e.dst not in uses_by_dst:
+            uses_by_dst[e.dst] = []
+        uses_by_dst[e.dst].append(e)
+
+    # Collect all config_reads_unresolved
+    unresolved = app.config_reads_unresolved
+    unresolved_by_reason = {}
+    for r in unresolved:
+        if r.reason not in unresolved_by_reason:
+            unresolved_by_reason[r.reason] = []
+        unresolved_by_reason[r.reason].append(r)
+
+    # Expected resolved keys from .env (env namespace):
+    # DATABASE_URL (literal), API_KEY (dataflow), SECRET_API_TOKEN (interproc)
+    expected_resolved_keys = {"DATABASE_URL", "API_KEY", "SECRET_API_TOKEN"}
+    actual_resolved_keys = set()
+    for src, edges in uses_by_dst.items():
+        if "/@external/" not in src:  # ConfigKey ids don't have /@external/
+            # Extract the key name from the ConfigKey id
+            # ConfigKey id format: can://python/<app>/<namespace>/<key>
+            parts = src.split("/")
+            if len(parts) > 0:
+                key_name = parts[-1]
+                actual_resolved_keys.add(key_name)
+
+    assert actual_resolved_keys >= expected_resolved_keys, \
+        f"Expected at least {expected_resolved_keys}, got {actual_resolved_keys}"
+
+    # Unresolved reads:
+    # Shape 4: multi-def (reason: non-literal)
+    # Shape 5: undefined-key (reason: undefined-key)
+    assert "non-literal" in unresolved_by_reason, \
+        f"Expected 'non-literal' unresolved, got reasons: {list(unresolved_by_reason.keys())}"
+    assert "undefined-key" in unresolved_by_reason, \
+        f"Expected 'undefined-key' unresolved, got reasons: {list(unresolved_by_reason.keys())}"
+
+    # Verify that undefined-key has a key value and non-literal does not
+    for r in unresolved_by_reason.get("undefined-key", []):
+        assert r.key == "NOT_DEFINED_ANYWHERE", \
+            f"Expected key 'NOT_DEFINED_ANYWHERE', got {r.key}"
+
+    for r in unresolved_by_reason.get("non-literal", []):
+        # Non-literal reasons should have no key (or key is None)
+        assert r.key is None, f"Expected key=None for non-literal, got {r.key}"
+
+
+def test_config_uses_tier_visibility(tmp_path):
+    """Verify config-use edges only appear at appropriate levels (#162)."""
+    # Literal tier visible at -a 2+
+    app_l2 = Codeanalyzer(AnalysisOptions(
+        input=FIXTURE, analysis_level=2, no_venv=True, cache_dir=tmp_path / "tier_l2",
+    )).analyze().application
+    uses_l2 = {e.dst for e in app_l2.config_uses}
+
+    # Variable-closing visible at -a 3+
+    app_l3 = Codeanalyzer(AnalysisOptions(
+        input=FIXTURE, analysis_level=3, no_venv=True, cache_dir=tmp_path / "tier_l3",
+    )).analyze().application
+    uses_l3 = {e.dst for e in app_l3.config_uses}
+
+    # Interproc visible at -a 4
+    app_l4 = Codeanalyzer(AnalysisOptions(
+        input=FIXTURE, analysis_level=4, no_venv=True, cache_dir=tmp_path / "tier_l4",
+    )).analyze().application
+    uses_l4 = {e.dst for e in app_l4.config_uses}
+
+    # Monotonicity: L2 ⊆ L3 ⊆ L4
+    assert uses_l2 <= uses_l3, \
+        f"L2 edges should be subset of L3: {uses_l2 - uses_l3} in L2 but not L3"
+    assert uses_l3 <= uses_l4, \
+        f"L3 edges should be subset of L4: {uses_l3 - uses_l4} in L3 but not L4"
+
+
+def test_config_uses_determinism(tmp_path):
+    """Verify config-use edges are deterministic across two identical runs."""
+    import json
+
+    app1 = Codeanalyzer(AnalysisOptions(
+        input=FIXTURE, analysis_level=4, no_venv=True, cache_dir=tmp_path / "det1",
+    )).analyze().application
+    app2 = Codeanalyzer(AnalysisOptions(
+        input=FIXTURE, analysis_level=4, no_venv=True, cache_dir=tmp_path / "det2",
+    )).analyze().application
+
+    # Serialize and compare config_uses
+    uses1 = json.dumps(
+        [{"src": e.src, "dst": e.dst, "prov": sorted(e.prov)} for e in sorted(app1.config_uses, key=lambda x: (x.src, x.dst))],
+        sort_keys=True,
+    )
+    uses2 = json.dumps(
+        [{"src": e.src, "dst": e.dst, "prov": sorted(e.prov)} for e in sorted(app2.config_uses, key=lambda x: (x.src, x.dst))],
+        sort_keys=True,
+    )
+    assert uses1 == uses2, "config_uses differ between runs"
+
+    # Serialize and compare config_reads_unresolved
+    unres1 = json.dumps(
+        [{"site": r.site, "callee": r.callee, "key": r.key, "reason": r.reason, "prov": sorted(r.prov)}
+         for r in sorted(app1.config_reads_unresolved, key=lambda x: (x.site, x.reason))],
+        sort_keys=True,
+    )
+    unres2 = json.dumps(
+        [{"site": r.site, "callee": r.callee, "key": r.key, "reason": r.reason, "prov": sorted(r.prov)}
+         for r in sorted(app2.config_reads_unresolved, key=lambda x: (x.site, x.reason))],
+        sort_keys=True,
+    )
+    assert unres1 == unres2, "config_reads_unresolved differ between runs"

--- a/test/test_call_argument_capture.py
+++ b/test/test_call_argument_capture.py
@@ -1,0 +1,101 @@
+"""Task 1 (#162): literal (`value`) and bare-name (`name`) capture on
+`PyCallArgument`, populated at symbol_table_builder.py:786 alongside the
+existing `ast_kind`/`inferred_type`."""
+from codeanalyzer.schema import model_dump_json, model_validate_json
+from codeanalyzer.schema.py_schema import (
+    BodyNode, PyApplication, PyCallable, PyCallArgument, PyModule,
+)
+from codeanalyzer.syntactic_analysis.symbol_table_builder import SymbolTableBuilder
+
+SRC = """\
+KEY = "irrelevant"
+
+
+class Obj:
+    attr = 1
+
+
+obj = Obj()
+
+
+def f(x):
+    return x
+
+
+def g():
+    f("DB_HOST")
+    f(3)
+    f(True)
+    f(None)
+    f(KEY)
+    f(obj.attr)
+"""
+
+
+def _g_call_sites(tmp_path):
+    """`f(...)` call sites from `g()`, in source order (`_iter_calls_in_scope`
+    walks the function body sequentially) -- indexing by position rather than
+    a hardcoded line number keeps this robust to SRC's exact formatting."""
+    (tmp_path / "mod.py").write_text(SRC)
+    module = SymbolTableBuilder(tmp_path, None).build_pymodule_from_file(tmp_path / "mod.py")
+    sites = sorted(module.functions["g"].call_sites, key=lambda cs: (cs.start_line, cs.start_column))
+    assert [cs.method_name for cs in sites] == ["f"] * 6
+    return sites
+
+
+def test_string_constant_is_json_encoded(tmp_path):
+    call = _g_call_sites(tmp_path)[0]
+    assert call.arguments[0].value == '"DB_HOST"'
+    assert call.arguments[0].name is None
+
+
+def test_int_constant_is_json_encoded(tmp_path):
+    call = _g_call_sites(tmp_path)[1]
+    assert call.arguments[0].value == "3"
+
+
+def test_bool_constant_is_json_encoded(tmp_path):
+    call = _g_call_sites(tmp_path)[2]
+    assert call.arguments[0].value == "true"
+
+
+def test_none_constant_is_json_encoded(tmp_path):
+    call = _g_call_sites(tmp_path)[3]
+    assert call.arguments[0].value == "null"
+
+
+def test_bare_name_captures_identifier_not_value(tmp_path):
+    call = _g_call_sites(tmp_path)[4]
+    assert call.arguments[0].value is None
+    assert call.arguments[0].name == "KEY"
+
+
+def test_attribute_argument_captures_neither(tmp_path):
+    call = _g_call_sites(tmp_path)[5]
+    assert call.arguments[0].value is None
+    assert call.arguments[0].name is None
+
+
+def test_l1_round_trip_through_compat_helpers():
+    fn = PyCallable(
+        name="f", path="a.py", signature="a.f",
+        body={"1:0": BodyNode(
+            kind="call",
+            arguments=[PyCallArgument(ast_kind="Constant", value='"DB_HOST"'),
+                       PyCallArgument(ast_kind="Name", name="KEY")],
+        )},
+    )
+    mod = PyModule(file_path="a.py", module_name="a", functions={"f": fn})
+    app = PyApplication(symbol_table={"a.py": mod})
+    back = model_validate_json(PyApplication, model_dump_json(app))
+    args = back.symbol_table["a.py"].functions["f"].body["1:0"].arguments
+    assert args[0].value == '"DB_HOST"' and args[0].name is None
+    assert args[1].value is None and args[1].name == "KEY"
+
+
+def test_old_payload_defaults_both_to_none():
+    """A payload written before #162 has no `value`/`name` keys at all --
+    must still validate, defaulting both to `None`."""
+    arg = PyCallArgument(ast_kind="Constant")
+    assert arg.value is None
+    assert arg.name is None

--- a/test/test_config_use_dataflow.py
+++ b/test/test_config_use_dataflow.py
@@ -1,0 +1,212 @@
+"""Task 3 (#162): the two dataflow tiers layered on config_use.py's literal
+tier -- intra (`-a 3`, DDG single-literal closure over the read's own
+callable) and interprocedural (`-a 4`, one level of caller-argument
+closure). Spec: docs/design/specs/2026-08-28-config-use-edge-design.md
+decision 2; plan: docs/design/plans/2026-08-28-config-use-edge.md Task 3.
+
+Both tiers only ever widen what the literal tier left unresolved -- a read
+resolved at a lower tier is never recomputed, and `prov` on a still-
+unresolved `PyConfigRead` lists every tier attempted (`["literal"]` at `-a
+2`, `["literal", "dataflow"]` at `-a 3`/`-a 4` -- the vocabulary has no
+separate intra/interproc tag).
+"""
+from codeanalyzer.core import Codeanalyzer
+from codeanalyzer.options import AnalysisOptions
+from codeanalyzer.schema import model_dump_json
+
+
+def _project(tmp_path, tag, mod_source, files):
+    proj = tmp_path / f"proj-{tag}"
+    proj.mkdir()
+    (proj / "mod.py").write_text(mod_source)
+    for name, content in files.items():
+        (proj / name).write_text(content)
+    return proj
+
+
+def _app(tmp_path, tag, mod_source, files, level):
+    proj = _project(tmp_path, tag, mod_source, files)
+    return Codeanalyzer(AnalysisOptions(
+        input=proj, analysis_level=level, no_venv=True, cache_dir=tmp_path / f"cache-{tag}",
+    )).analyze().application
+
+
+# --- intra tier (-a 3) ------------------------------------------------------
+
+def test_variable_closing_to_one_literal_resolves_at_l3_not_l2(tmp_path):
+    source = (
+        "import os\n\n"
+        "def read_host():\n"
+        "    KEY = 'DB_HOST'\n"
+        "    os.getenv(KEY)\n"
+    )
+    files = {".env": "DB_HOST=example.com\n"}
+
+    l2 = _app(tmp_path, "l2", source, files, level=2)
+    assert l2.config_uses == []
+    (read,) = l2.config_reads_unresolved
+    assert read.reason == "non-literal"
+    assert read.prov == ["literal"]
+
+    l3 = _app(tmp_path, "l3", source, files, level=3)
+    assert l3.config_reads_unresolved == []
+    (edge,) = l3.config_uses
+    assert edge.prov == ["dataflow"]
+    key = l3.artifacts[".env"].config_keys[0]
+    assert edge.dst == key.id
+
+
+def test_two_differing_defs_stay_unresolved_at_every_level(tmp_path):
+    source = (
+        "import os\n\n"
+        "def read_host(flag):\n"
+        "    if flag:\n"
+        "        KEY = 'DB_HOST'\n"
+        "    else:\n"
+        "        KEY = 'DB_PORT'\n"
+        "    os.getenv(KEY)\n"
+    )
+    files = {".env": "DB_HOST=example.com\nDB_PORT=5432\n"}
+    for level in (3, 4):
+        app = _app(tmp_path, f"differ-{level}", source, files, level=level)
+        assert app.config_uses == []
+        (read,) = app.config_reads_unresolved
+        assert read.reason == "non-literal"
+        assert read.prov == ["literal", "dataflow"]
+
+
+def test_loop_carried_key_stays_unresolved(tmp_path):
+    source = (
+        "import os\n\n"
+        "def read_many():\n"
+        "    for k in ['DB_HOST', 'DB_PORT']:\n"
+        "        os.getenv(k)\n"
+    )
+    files = {".env": "DB_HOST=example.com\nDB_PORT=5432\n"}
+    app = _app(tmp_path, "loop", source, files, level=3)
+    assert app.config_uses == []
+    (read,) = app.config_reads_unresolved
+    assert read.reason == "non-literal"
+
+
+# --- interprocedural tier (-a 4) -------------------------------------------
+
+def test_param_passed_literal_resolves_at_l4_not_l3(tmp_path):
+    source = (
+        "import os\n\n"
+        "def read(name):\n"
+        "    os.getenv(name)\n\n"
+        "def caller():\n"
+        "    read('DB_HOST')\n"
+    )
+    files = {".env": "DB_HOST=example.com\n"}
+
+    l3 = _app(tmp_path, "l3-interproc", source, files, level=3)
+    assert l3.config_uses == []
+    (read,) = l3.config_reads_unresolved
+    assert read.reason == "non-literal"
+    assert read.prov == ["literal", "dataflow"]
+
+    l4 = _app(tmp_path, "l4-interproc", source, files, level=4)
+    assert l4.config_reads_unresolved == []
+    (edge,) = l4.config_uses
+    assert edge.prov == ["dataflow"]
+
+
+def test_two_call_sites_with_different_literals_stay_unresolved(tmp_path):
+    source = (
+        "import os\n\n"
+        "def read(name):\n"
+        "    os.getenv(name)\n\n"
+        "def caller_a():\n"
+        "    read('DB_HOST')\n\n"
+        "def caller_b():\n"
+        "    read('DB_PORT')\n"
+    )
+    files = {".env": "DB_HOST=example.com\nDB_PORT=5432\n"}
+    app = _app(tmp_path, "two-sites", source, files, level=4)
+    assert app.config_uses == []
+    (read,) = app.config_reads_unresolved
+    assert read.reason == "non-literal"
+
+
+def test_shadowed_parameter_is_not_misattributed_to_caller_argument(tmp_path):
+    """A parameter reassigned locally before the read resolves (or not) from
+    its OWN value, never from what a caller passed for that parameter name.
+    Guards the interproc tier against re-deriving a value from callers once
+    the intra tier already closed the read on a literal that simply names
+    no declared key (undefined-key) -- the shadowing write, not the call
+    site, is this read's real source."""
+    source = (
+        "import os\n\n"
+        "def read(key):\n"
+        "    key = 'NOT_A_REAL_KEY'\n"
+        "    os.getenv(key)\n\n"
+        "def caller():\n"
+        "    read('DB_HOST')\n"
+    )
+    files = {".env": "DB_HOST=example.com\n"}
+    app = _app(tmp_path, "shadow", source, files, level=4)
+    assert app.config_uses == []
+    (read,) = app.config_reads_unresolved
+    assert read.reason == "undefined-key"
+    assert read.key == "NOT_A_REAL_KEY"
+
+
+# --- monotonicity ------------------------------------------------------------
+
+def test_config_uses_monotonic_across_levels(tmp_path):
+    """`-a 2` (literal only) subset `-a 3` (+intra) subset `-a 4`
+    (+interproc) -- same additive contract as the DDG's `prov` widening
+    (CI-gate test, per the plan's Global Constraints)."""
+    source = (
+        "import os\n\n"
+        "def read_literal():\n"
+        "    os.getenv('DB_HOST')\n\n"
+        "def read_closed():\n"
+        "    KEY = 'DB_PORT'\n"
+        "    os.getenv(KEY)\n\n"
+        "def read_param(name):\n"
+        "    os.getenv(name)\n\n"
+        "def caller():\n"
+        "    read_param('DB_USER')\n"
+    )
+    files = {".env": "DB_HOST=example.com\nDB_PORT=5432\nDB_USER=admin\n"}
+    # One project dir shared across levels -- app_name (and so every `can://`
+    # id) derives from the input dir name, so comparing edge sets across
+    # separately-named `proj-mono-N` dirs would spuriously never intersect.
+    proj = _project(tmp_path, "mono", source, files)
+
+    def edge_set(level):
+        app = Codeanalyzer(AnalysisOptions(
+            input=proj, analysis_level=level, no_venv=True,
+            cache_dir=tmp_path / f"cache-mono-{level}",
+        )).analyze().application
+        return {(e.src, e.dst) for e in app.config_uses}
+
+    l2, l3, l4 = edge_set(2), edge_set(3), edge_set(4)
+    assert l2 <= l3 <= l4
+    assert len(l2) == 1
+    assert len(l3) == 2
+    assert len(l4) == 3
+
+
+# --- determinism -------------------------------------------------------------
+
+def test_dataflow_tier_determinism_two_runs(tmp_path):
+    source = (
+        "import os\n\n"
+        "def read_host():\n"
+        "    KEY = 'DB_HOST'\n"
+        "    os.getenv(KEY)\n"
+    )
+    proj = _project(tmp_path, "determinism", source, {".env": "DB_HOST=example.com\n"})
+
+    def run(tag):
+        return Codeanalyzer(AnalysisOptions(
+            input=proj, analysis_level=4, no_venv=True, cache_dir=tmp_path / f"cache-{tag}",
+        )).analyze().application
+
+    a = model_dump_json(run("r1"))
+    b = model_dump_json(run("r2"))
+    assert a == b

--- a/test/test_config_use_dataflow.py
+++ b/test/test_config_use_dataflow.py
@@ -244,12 +244,66 @@ def test_shadowed_parameter_is_not_misattributed_to_caller_argument(tmp_path):
     assert read.key == "NOT_A_REAL_KEY"
 
 
+def test_conditionally_shadowed_param_is_not_misattributed_to_caller_argument(tmp_path):
+    """Regression: a parameter reassigned on only SOME paths, to a
+    non-literal value the intra tier can't close (`key_literal` stays
+    `None`, never "closed-but-undeclared") -- the existing shadow guard only
+    catches a shadow that closes on a literal. Before the fix, the interproc
+    tier had no way to see the local rebind and minted an edge straight from
+    the caller's literal, ignoring it. Must stay unresolved at every level."""
+    source = (
+        "import os\n\n"
+        "def read(key):\n"
+        "    if not key:\n"
+        "        key = str(len('x'))\n"
+        "    return os.getenv(key)\n\n"
+        "def caller():\n"
+        "    read('DB_HOST')\n"
+    )
+    files = {".env": "DB_HOST=example.com\n"}
+    for level in (2, 3, 4):
+        app = _app(tmp_path, f"shadow-cond-{level}", source, files, level=level)
+        assert app.config_uses == []
+        (read,) = app.config_reads_unresolved
+        assert read.reason == "non-literal"
+
+
+def test_module_scope_caller_with_different_literal_stays_unresolved(tmp_path):
+    """Regression: a module-scope call site (`call_graph` src is a
+    `can://.../@external/<module>` id, #131 modeling) never resolves in
+    `_index_callables`. Before the fix, `_call_sites_targeting` silently
+    dropped it, so the ONE caller the index could see (passing 'DB_HOST')
+    looked like unanimous agreement and the read resolved -- even though
+    the invisible module-scope call passes a different literal."""
+    source = (
+        "import os\n\n"
+        "def read(name):\n"
+        "    os.getenv(name)\n\n"
+        "def caller():\n"
+        "    read('DB_HOST')\n\n"
+        "read('OTHER_KEY')\n"
+    )
+    files = {".env": "DB_HOST=example.com\nOTHER_KEY=x\n"}
+    app = _app(tmp_path, "modscope", source, files, level=4)
+    assert app.config_uses == []
+    (read,) = app.config_reads_unresolved
+    assert read.reason == "non-literal"
+
+
 # --- monotonicity ------------------------------------------------------------
 
 def test_config_uses_monotonic_across_levels(tmp_path):
     """`-a 2` (literal only) subset `-a 3` (+intra) subset `-a 4`
     (+interproc) -- same additive contract as the DDG's `prov` widening
-    (CI-gate test, per the plan's Global Constraints)."""
+    (CI-gate test, per the plan's Global Constraints).
+
+    `read_alias` regression-tests a points-to alias edge (`obj.attr =
+    KEY` may-aliases bare `KEY`, since an unsuffixed local's empty suffix is
+    oracle-compatible with any attribute path) used to reach the read with a
+    non-closing def and kill a closure the L3 ssa-only set resolved cleanly
+    -- present at `-a 3`, silently absent at `-a 4`, breaking monotonicity.
+    Fixed by consulting only `prov=["ssa"]` reaching defs; this shape must
+    now resolve identically at both levels."""
     source = (
         "import os\n\n"
         "def read_literal():\n"
@@ -257,12 +311,16 @@ def test_config_uses_monotonic_across_levels(tmp_path):
         "def read_closed():\n"
         "    KEY = 'DB_PORT'\n"
         "    os.getenv(KEY)\n\n"
+        "def read_alias():\n"
+        "    KEY = 'DB_NAME'\n"
+        "    obj.attr = KEY\n"
+        "    os.getenv(KEY)\n\n"
         "def read_param(name):\n"
         "    os.getenv(name)\n\n"
         "def caller():\n"
         "    read_param('DB_USER')\n"
     )
-    files = {".env": "DB_HOST=example.com\nDB_PORT=5432\nDB_USER=admin\n"}
+    files = {".env": "DB_HOST=example.com\nDB_PORT=5432\nDB_USER=admin\nDB_NAME=mydb\n"}
     # One project dir shared across levels -- app_name (and so every `can://`
     # id) derives from the input dir name, so comparing edge sets across
     # separately-named `proj-mono-N` dirs would spuriously never intersect.
@@ -278,8 +336,8 @@ def test_config_uses_monotonic_across_levels(tmp_path):
     l2, l3, l4 = edge_set(2), edge_set(3), edge_set(4)
     assert l2 <= l3 <= l4
     assert len(l2) == 1
-    assert len(l3) == 2
-    assert len(l4) == 3
+    assert len(l3) == 3
+    assert len(l4) == 4
 
 
 # --- determinism -------------------------------------------------------------

--- a/test/test_config_use_dataflow.py
+++ b/test/test_config_use_dataflow.py
@@ -10,9 +10,18 @@ unresolved `PyConfigRead` lists every tier attempted (`["literal"]` at `-a
 2`, `["literal", "dataflow"]` at `-a 3`/`-a 4` -- the vocabulary has no
 separate intra/interproc tag).
 """
+import json
+
+from codeanalyzer.artifacts.config_use import (
+    Rule, _Read, dataflow_intra_tier, dataflow_interproc_tier, resolve_uses,
+)
 from codeanalyzer.core import Codeanalyzer
 from codeanalyzer.options import AnalysisOptions
 from codeanalyzer.schema import model_dump_json
+from codeanalyzer.schema.py_schema import (
+    BodyNode, DdgEdge, PyApplication, PyArtifact, PyCallArgument, PyCallable,
+    PyCallableParameter, PyCallEdge, PyConfigKey, PyExternalSymbol, PyModule, Span,
+)
 
 
 def _project(tmp_path, tag, mod_source, files):
@@ -29,6 +38,88 @@ def _app(tmp_path, tag, mod_source, files, level):
     return Codeanalyzer(AnalysisOptions(
         input=proj, analysis_level=level, no_venv=True, cache_dir=tmp_path / f"cache-{tag}",
     )).analyze().application
+
+
+# --- hand-built helpers (review carried items) ------------------------------
+# The tier functions (`dataflow_intra_tier`/`dataflow_interproc_tier`) are
+# pure functions of `(List[_Read], PyApplication)` -- exercised directly
+# here, bypassing `detect_config_reads`/the Codeanalyzer pipeline entirely,
+# same motivation as `test_config_use_literal.py`'s `_hand_app`. Each
+# callable lives in its own tiny module so span byte-offsets never need to
+# account for another callable's text sharing the same `source` string.
+
+_EXT_ID = "can://python/app/@external/os/getenv"
+_ENV_RULE = Rule(id="os.getenv", module="os", callable="getenv", key_arg=0, namespaces=("env",))
+
+
+def _span(source: str, text: str, occurrence: int = 0) -> Span:
+    """Byte span of `text`'s `occurrence`-th (0-based) match in `source` --
+    only `.bytes` is read by the tiers under test, so `start`/`end` (line,
+    col) are unused placeholders."""
+    lo = -1
+    for _ in range(occurrence + 1):
+        lo = source.index(text, lo + 1)
+    hi = lo + len(text)
+    return Span(start=(1, lo), end=(1, hi), bytes=(lo, hi))
+
+
+def _const(value) -> PyCallArgument:
+    return PyCallArgument(ast_kind="Constant", value=json.dumps(value))
+
+
+def _name_arg(identifier: str) -> PyCallArgument:
+    return PyCallArgument(ast_kind="Name", name=identifier)
+
+
+def _module(file_path: str, source: str, callable_: PyCallable) -> PyModule:
+    return PyModule(file_path=file_path, module_name=file_path[:-3], source=source,
+                     functions={callable_.name: callable_})
+
+
+def _hand_app(modules: dict, call_graph=(), artifacts=None) -> PyApplication:
+    return PyApplication(
+        symbol_table=modules,
+        external_symbols={_EXT_ID: PyExternalSymbol(id=_EXT_ID, name="getenv", module="os")},
+        call_graph=list(call_graph), artifacts=artifacts or {},
+    )
+
+
+def _env_artifact(*keys: str) -> dict:
+    art_id = "can://artifact/app/.env"
+    return {".env": PyArtifact(
+        id=art_id, path=".env", format="env",
+        config_keys=[PyConfigKey(id=f"{art_id}@key/{k}", key=k, namespace="env") for k in keys],
+    )}
+
+
+def _resolve(read, app, *tiers):
+    return resolve_uses([read], app, tier_fns=list(tiers))
+
+
+def _target_with_param() -> PyCallable:
+    """`def f(key): os.getenv(key)` -- the shared interproc target: `key`
+    is a parameter with no local reassignment, so the intra tier always
+    fails to close it (no reaching def reaches the call at all) and the
+    read falls through to the interproc tier, same as the real pipeline."""
+    return PyCallable(
+        name="f", path="f.py", signature="f.f", id="f_id",
+        parameters=[PyCallableParameter(name="key")],
+        body={"read": BodyNode(kind="call", callee=_EXT_ID, arguments=[_name_arg("key")])},
+    )
+
+
+def _target_read() -> _Read:
+    return _Read(site="f_id@read", callable_id="f_id", local_id="read", callee=_EXT_ID,
+                 rule=_ENV_RULE, key_literal=None, key_name="key")
+
+
+def _caller(file_path: str, callable_id: str, argument) -> PyModule:
+    """A no-frills caller: one function, one call to `f_id` at position 0."""
+    c = PyCallable(
+        name="caller", path=file_path, signature=f"{file_path}.caller", id=callable_id,
+        body={"call": BodyNode(kind="call", callee="f_id", arguments=[argument])},
+    )
+    return _module(file_path, "", c)
 
 
 # --- intra tier (-a 3) ------------------------------------------------------
@@ -210,3 +301,231 @@ def test_dataflow_tier_determinism_two_runs(tmp_path):
     a = model_dump_json(run("r1"))
     b = model_dump_json(run("r2"))
     assert a == b
+
+
+# --- interproc multi-site agreement (review MEDIUM) -------------------------
+
+def test_interproc_two_sites_agreeing_on_same_literal_resolves():
+    """Two independent callers both passing the identical literal -- "all
+    sites agree" holds trivially when there's exactly one distinct value."""
+    app = _hand_app(
+        {
+            "f.py": _module("f.py", "", _target_with_param()),
+            "a.py": _caller("a.py", "a_id", _const("DB_HOST")),
+            "b.py": _caller("b.py", "b_id", _const("DB_HOST")),
+        },
+        call_graph=[PyCallEdge(src="a_id", dst="f_id"), PyCallEdge(src="b_id", dst="f_id")],
+        artifacts=_env_artifact("DB_HOST"),
+    )
+    edges, unresolved = _resolve(_target_read(), app, dataflow_intra_tier, dataflow_interproc_tier)
+    assert unresolved == []
+    (edge,) = edges
+    assert edge.prov == ["dataflow"]
+    assert edge.dst == app.artifacts[".env"].config_keys[0].id
+
+
+def test_interproc_direct_literal_plus_caller_side_closed_variable_resolves():
+    """One site passes the literal directly; the other passes a bare Name
+    that itself closes to the same literal one hop up, in ITS OWN caller
+    (the `_site_literal` Name branch) -- both still agree."""
+    src_b = 'V = "DB_HOST"\nf(V)\n'
+    caller_b = PyCallable(
+        name="caller", path="b.py", signature="b.caller", id="b_id",
+        body={
+            "def_v": BodyNode(kind="statement", span=_span(src_b, 'V = "DB_HOST"')),
+            "call": BodyNode(kind="call", callee="f_id", span=_span(src_b, "f(V)"),
+                              arguments=[_name_arg("V")]),
+        },
+        ddg=[DdgEdge(src="def_v", dst="call", var="V", prov=["ssa"])],
+    )
+    app = _hand_app(
+        {
+            "f.py": _module("f.py", "", _target_with_param()),
+            "a.py": _caller("a.py", "a_id", _const("DB_HOST")),
+            "b.py": _module("b.py", src_b, caller_b),
+        },
+        call_graph=[PyCallEdge(src="a_id", dst="f_id"), PyCallEdge(src="b_id", dst="f_id")],
+        artifacts=_env_artifact("DB_HOST"),
+    )
+    edges, unresolved = _resolve(_target_read(), app, dataflow_intra_tier, dataflow_interproc_tier)
+    assert unresolved == []
+    (edge,) = edges
+    assert edge.prov == ["dataflow"]
+
+
+def test_interproc_literal_plus_non_closing_variable_stays_unresolved():
+    """One site's literal is not enough -- a site whose Name argument has
+    no reaching def at all (nothing for the one-hop closure to find) means
+    "all sites agree" can never be confirmed, so the read stays unresolved
+    even though the OTHER site is a clean literal."""
+    src_b = "f(V)\n"
+    caller_b = PyCallable(
+        name="caller", path="b.py", signature="b.caller", id="b_id",
+        body={"call": BodyNode(kind="call", callee="f_id", span=_span(src_b, "f(V)"),
+                                arguments=[_name_arg("V")])},
+        # no ddg edge for "V" -- nothing reaches, so the caller-side hop can't close it
+    )
+    app = _hand_app(
+        {
+            "f.py": _module("f.py", "", _target_with_param()),
+            "a.py": _caller("a.py", "a_id", _const("DB_HOST")),
+            "b.py": _module("b.py", src_b, caller_b),
+        },
+        call_graph=[PyCallEdge(src="a_id", dst="f_id"), PyCallEdge(src="b_id", dst="f_id")],
+        artifacts=_env_artifact("DB_HOST"),
+    )
+    edges, unresolved = _resolve(_target_read(), app, dataflow_intra_tier, dataflow_interproc_tier)
+    assert edges == []
+    (read,) = unresolved
+    assert read.reason == "non-literal"
+
+
+# --- def-shape rejections (review LOW) --------------------------------------
+# `_assign_literal` accepts only a plain single-target `Name = <str
+# Constant>` Assign. Each shape below is a real Python statement that is
+# NOT that shape, pinned so a future loosening of the check is deliberate.
+
+def _assert_never_closes(read, app):
+    """`reason == "non-literal"` at both `-a 3` (intra only) and `-a 4`
+    (intra + interproc) -- these reads never carry a `key_name` that is
+    also a parameter, so interproc never gets a chance to rescue them
+    either; asserting both levels pins that the def-shape rejection is not
+    an accident of which tier happened to run."""
+    for tiers in ((dataflow_intra_tier,), (dataflow_intra_tier, dataflow_interproc_tier)):
+        edges, unresolved = _resolve(read, app, *tiers)
+        assert edges == []
+        (r,) = unresolved
+        assert r.reason == "non-literal"
+
+
+def _single_def_app(source: str, def_text: str, call_text: str) -> PyApplication:
+    c = PyCallable(
+        name="f", path="f.py", signature="f.f", id="f_id",
+        body={
+            "def": BodyNode(kind="statement", span=_span(source, def_text)),
+            "call": BodyNode(kind="call", callee=_EXT_ID, span=_span(source, call_text),
+                              arguments=[_name_arg("KEY")]),
+        },
+        ddg=[DdgEdge(src="def", dst="call", var="KEY", prov=["ssa"])],
+    )
+    return _hand_app({"f.py": _module("f.py", source, c)}, artifacts=_env_artifact("DB_HOST"))
+
+
+def _single_def_read() -> _Read:
+    return _Read(site="f_id@call", callable_id="f_id", local_id="call", callee=_EXT_ID,
+                 rule=_ENV_RULE, key_literal=None, key_name="KEY")
+
+
+def test_annassign_def_shape_is_rejected():
+    source = 'KEY: str = "DB_HOST"\nos.getenv(KEY)\n'
+    app = _single_def_app(source, 'KEY: str = "DB_HOST"', "os.getenv(KEY)")
+    _assert_never_closes(_single_def_read(), app)
+
+
+def test_augassign_def_shape_is_rejected():
+    source = 'KEY += "DB_HOST"\nos.getenv(KEY)\n'
+    app = _single_def_app(source, 'KEY += "DB_HOST"', "os.getenv(KEY)")
+    _assert_never_closes(_single_def_read(), app)
+
+
+def test_tuple_unpack_def_shape_is_rejected():
+    source = 'KEY, other = "DB_HOST", 1\nos.getenv(KEY)\n'
+    app = _single_def_app(source, 'KEY, other = "DB_HOST", 1', "os.getenv(KEY)")
+    _assert_never_closes(_single_def_read(), app)
+
+
+# --- agree-rule halves (review LOW) -----------------------------------------
+
+def test_two_identical_literal_defs_close():
+    """Both branches assign the SAME literal -- two DDG-reaching defs, one
+    distinct value, closes (spec caveat: identical duplicates count as
+    closed, pinned independently of the differing-defs case)."""
+    source = (
+        'if flag:\n'
+        '    KEY = "DB_HOST"\n'
+        'else:\n'
+        '    KEY = "DB_HOST"\n'
+        'os.getenv(KEY)\n'
+    )
+    c = PyCallable(
+        name="f", path="f.py", signature="f.f", id="f_id",
+        body={
+            "def_a": BodyNode(kind="statement", span=_span(source, 'KEY = "DB_HOST"', occurrence=0)),
+            "def_b": BodyNode(kind="statement", span=_span(source, 'KEY = "DB_HOST"', occurrence=1)),
+            "call": BodyNode(kind="call", callee=_EXT_ID, span=_span(source, "os.getenv(KEY)"),
+                              arguments=[_name_arg("KEY")]),
+        },
+        ddg=[
+            DdgEdge(src="def_a", dst="call", var="KEY", prov=["ssa"]),
+            DdgEdge(src="def_b", dst="call", var="KEY", prov=["ssa"]),
+        ],
+    )
+    app = _hand_app({"f.py": _module("f.py", source, c)}, artifacts=_env_artifact("DB_HOST"))
+    read = _Read(site="f_id@call", callable_id="f_id", local_id="call", callee=_EXT_ID,
+                 rule=_ENV_RULE, key_literal=None, key_name="KEY")
+    edges, unresolved = _resolve(read, app, dataflow_intra_tier)
+    assert unresolved == []
+    (edge,) = edges
+    assert edge.prov == ["dataflow"]
+
+
+def test_literal_def_plus_non_literal_def_stays_unresolved():
+    """One reaching def closes on a literal; the other is a call (not a
+    Constant) -- any single non-closing reaching def kills resolution even
+    though a DIFFERENT def would have closed on its own."""
+    source = 'KEY = "DB_HOST"\nKEY = compute()\nos.getenv(KEY)\n'
+    lit_text = 'KEY = "DB_HOST"'
+    call_def_text = "KEY = compute()"
+    c = PyCallable(
+        name="f", path="f.py", signature="f.f", id="f_id",
+        body={
+            "def_lit": BodyNode(kind="statement", span=_span(source, lit_text)),
+            "def_call": BodyNode(kind="statement", span=_span(source, call_def_text)),
+            "call": BodyNode(kind="call", callee=_EXT_ID, span=_span(source, "os.getenv(KEY)"),
+                              arguments=[_name_arg("KEY")]),
+        },
+        ddg=[
+            DdgEdge(src="def_lit", dst="call", var="KEY", prov=["ssa"]),
+            DdgEdge(src="def_call", dst="call", var="KEY", prov=["ssa"]),
+        ],
+    )
+    app = _hand_app({"f.py": _module("f.py", source, c)}, artifacts=_env_artifact("DB_HOST"))
+    read = _Read(site="f_id@call", callable_id="f_id", local_id="call", callee=_EXT_ID,
+                 rule=_ENV_RULE, key_literal=None, key_name="KEY")
+    edges, unresolved = _resolve(read, app, dataflow_intra_tier)
+    assert edges == []
+    (r,) = unresolved
+    assert r.reason == "non-literal"
+
+
+# --- self-recursion guard (review LOW) --------------------------------------
+
+def test_self_recursive_call_site_terminates_without_misattribution():
+    """`def f(key): os.getenv(key)` plus a self-call `f("X")` -- the ONLY
+    recorded caller of `f` is `f` itself. The self-call's argument is a
+    direct literal, so it resolves through `_site_literal`'s value branch
+    without ever consulting `visited` (that guard only gates the Name/
+    intra-closure branch) -- this terminates cleanly (no recursive
+    re-entry into interproc resolution) and traces to exactly "X", never
+    silently dropping the read or misattributing it to an unrelated
+    declared key."""
+    f = PyCallable(
+        name="f", path="f.py", signature="f.f", id="f_id",
+        parameters=[PyCallableParameter(name="key")],
+        body={
+            "read": BodyNode(kind="call", callee=_EXT_ID, arguments=[_name_arg("key")]),
+            "self_call": BodyNode(kind="call", callee="f_id", arguments=[_const("X")]),
+        },
+    )
+    app = _hand_app(
+        {"f.py": _module("f.py", "", f)},
+        call_graph=[PyCallEdge(src="f_id", dst="f_id")],
+        artifacts=_env_artifact("DB_HOST"),
+    )
+    read = _Read(site="f_id@read", callable_id="f_id", local_id="read", callee=_EXT_ID,
+                 rule=_ENV_RULE, key_literal=None, key_name="key")
+    edges, unresolved = _resolve(read, app, dataflow_intra_tier, dataflow_interproc_tier)
+    assert edges == []
+    (r,) = unresolved
+    assert r.reason == "undefined-key"
+    assert r.key == "X"

--- a/test/test_config_use_literal.py
+++ b/test/test_config_use_literal.py
@@ -1,0 +1,150 @@
+"""Task 2 (#162): config_use_rules.yml detector table + the literal tier.
+
+`os.getenv`/`os.environ.get` reads against `.env`-defined keys resolve to
+`PY_USES_CONFIG` edges (`prov=["literal"]`); a key that decodes to a string
+but matches no declared `PyConfigKey` becomes a first-class
+`PyConfigRead(reason="undefined-key")`; a key that isn't a string literal at
+all becomes `reason="non-literal"`. See `config_use.py`'s module docstring
+for the `os.environ["X"]` subscript finding the first test below confirms.
+"""
+from codeanalyzer.core import Codeanalyzer
+from codeanalyzer.options import AnalysisOptions
+from codeanalyzer.schema import model_dump_json
+from codeanalyzer.syntactic_analysis.symbol_table_builder import SymbolTableBuilder
+
+
+def _project(tmp_path, tag, mod_source, files):
+    proj = tmp_path / f"proj-{tag}"
+    proj.mkdir()
+    (proj / "mod.py").write_text(mod_source)
+    for name, content in files.items():
+        (proj / name).write_text(content)
+    return proj
+
+
+def _app(tmp_path, tag, mod_source, files, level=2):
+    proj = _project(tmp_path, tag, mod_source, files)
+    return Codeanalyzer(AnalysisOptions(
+        input=proj, analysis_level=level, no_venv=True, cache_dir=tmp_path / f"cache-{tag}",
+    )).analyze().application
+
+
+# --- controller ruling (b): empirical subscript probe -----------------------
+
+def test_environ_subscript_is_not_lowered_to_a_call_node(tmp_path):
+    """`os.environ["X"]` is an `ast.Subscript`, not `ast.Call` --
+    `_iter_calls_in_scope` (symbol_table_builder.py) only ever yields
+    `ast.Call` nodes, so this produces zero call sites. Confirms the
+    recorded gap documented in config_use.py's module docstring, rather
+    than assuming it."""
+    (tmp_path / "mod.py").write_text(
+        "import os\n\ndef read():\n    return os.environ['DB_HOST']\n"
+    )
+    module = SymbolTableBuilder(tmp_path, None).build_pymodule_from_file(tmp_path / "mod.py")
+    assert module.functions["read"].call_sites == []
+
+
+# --- literal tier -------------------------------------------------------
+
+def test_literal_key_resolves_to_env_config_key(tmp_path):
+    app = _app(
+        tmp_path, "literal",
+        "import os\n\ndef read_host():\n    return os.getenv('DB_HOST')\n",
+        {".env": "DB_HOST=example.com\n"},
+    )
+    assert app.config_reads_unresolved == []
+    (edge,) = app.config_uses
+    assert edge.prov == ["literal"]
+
+    key = app.artifacts[".env"].config_keys[0]
+    assert key.key == "DB_HOST" and key.namespace == "env"
+    assert edge.dst == key.id
+
+    fn = app.symbol_table["mod.py"].functions["read_host"]
+    assert edge.src.startswith(fn.id + "@")
+
+
+def test_undefined_key_is_first_class_unresolved(tmp_path):
+    app = _app(
+        tmp_path, "undefined",
+        "import os\n\ndef read_missing():\n    return os.getenv('MISSING')\n",
+        {".env": "DB_HOST=example.com\n"},
+    )
+    assert app.config_uses == []
+    (read,) = app.config_reads_unresolved
+    assert read.reason == "undefined-key"
+    assert read.key == "MISSING"
+    assert read.prov == ["literal"]
+    assert read.callee.endswith("/@external/os/getenv")
+
+
+def test_non_literal_key_is_unresolved_at_l2(tmp_path):
+    app = _app(
+        tmp_path, "nonliteral",
+        "import os\n\ndef read_dynamic(kvar):\n    return os.getenv(kvar)\n",
+        {".env": "DB_HOST=example.com\n"},
+    )
+    assert app.config_uses == []
+    (read,) = app.config_reads_unresolved
+    assert read.reason == "non-literal"
+    assert read.key is None
+
+
+def test_level_one_never_populates_config_uses(tmp_path):
+    """Literal tier needs a resolved callee -- L1 body data has `callee=None`
+    on every call node, so detection finds nothing to match."""
+    app = _app(
+        tmp_path, "l1",
+        "import os\n\ndef read_host():\n    return os.getenv('DB_HOST')\n",
+        {".env": "DB_HOST=example.com\n"},
+        level=1,
+    )
+    assert app.config_uses == []
+    assert app.config_reads_unresolved == []
+
+
+# --- namespace preference ------------------------------------------------
+
+def test_namespace_preference_ini_before_properties(tmp_path):
+    app = _app(
+        tmp_path, "namespace",
+        "import configparser\n\n"
+        "def read_option():\n"
+        "    cp = configparser.ConfigParser()\n"
+        "    return cp.get('db', 'host')\n",
+        {
+            "app.ini": "[db]\nhost = ini-value\n",
+            "app.properties": "host=props-value\n",
+        },
+    )
+    ini_key = app.artifacts["app.ini"].config_keys[0]
+    props_key = app.artifacts["app.properties"].config_keys[0]
+    assert ini_key.key == "db.host" and ini_key.namespace == "ini"
+    assert props_key.key == "host" and props_key.namespace == "properties"
+
+    assert app.config_reads_unresolved == []
+    (edge,) = app.config_uses
+    assert edge.dst == ini_key.id
+    assert edge.prov == ["literal"]
+
+
+# --- determinism ----------------------------------------------------------
+
+def test_determinism_two_runs(tmp_path):
+    """Same project (so the same app_name/ids), independent cache dirs --
+    isolates config_use's own determinism from the id-scheme churn a
+    different `proj-*` directory name would otherwise introduce."""
+    proj = _project(
+        tmp_path, "determinism",
+        "import os\n\ndef read_host():\n    return os.getenv('DB_HOST')\n",
+        {".env": "DB_HOST=example.com\n"},
+    )
+
+    def run(tag):
+        return Codeanalyzer(AnalysisOptions(
+            input=proj, analysis_level=2, no_venv=True, cache_dir=tmp_path / f"cache-{tag}",
+        )).analyze().application
+
+    a = model_dump_json(run("r1"))
+    b = model_dump_json(run("r2"))
+    assert a == b

--- a/test/test_config_use_literal.py
+++ b/test/test_config_use_literal.py
@@ -6,10 +6,26 @@ but matches no declared `PyConfigKey` becomes a first-class
 `PyConfigRead(reason="undefined-key")`; a key that isn't a string literal at
 all becomes `reason="non-literal"`. See `config_use.py`'s module docstring
 for the `os.environ["X"]` subscript finding the first test below confirms.
+
+The per-rule and rules-loader sections below hand-build a `PyApplication`
+directly (same idiom as `test_v2_l2.py`'s `_app_with_one_call`) rather than
+running the full Codeanalyzer pipeline -- detector-rule matching and
+literal-tier resolution don't need Jedi/PyCG/ray, and a full pipeline run
+per rule is both slower and a load-coupled flake class of its own (PyCG
+shard timeouts under load produce spurious L2 failures).
 """
+import json
+
+import pytest
+
+from codeanalyzer.artifacts.config_use import ConfigUseRulesError, detect_config_reads, load_rules, resolve_uses
 from codeanalyzer.core import Codeanalyzer
 from codeanalyzer.options import AnalysisOptions
 from codeanalyzer.schema import model_dump_json
+from codeanalyzer.schema.py_schema import (
+    BodyNode, PyApplication, PyArtifact, PyCallArgument, PyCallable, PyConfigKey,
+    PyExternalSymbol, PyModule,
+)
 from codeanalyzer.syntactic_analysis.symbol_table_builder import SymbolTableBuilder
 
 
@@ -27,6 +43,36 @@ def _app(tmp_path, tag, mod_source, files, level=2):
     return Codeanalyzer(AnalysisOptions(
         input=proj, analysis_level=level, no_venv=True, cache_dir=tmp_path / f"cache-{tag}",
     )).analyze().application
+
+
+def _literal_arg(value) -> PyCallArgument:
+    return PyCallArgument(ast_kind="Constant", value=json.dumps(value))
+
+
+def _artifact(path: str, fmt: str, key: str, namespace: str) -> dict:
+    art_id = f"can://artifact/app/{path}"
+    return {path: PyArtifact(
+        id=art_id, path=path, format=fmt,
+        config_keys=[PyConfigKey(id=f"{art_id}@key/{key}", key=key, namespace=namespace)],
+    )}
+
+
+def _hand_app(module: str, callable_name: str, arguments, artifacts=None) -> PyApplication:
+    """A `PyApplication` with exactly one callable containing one call to
+    `module.callable_name` at its detector-rule key-argument position(s) --
+    the minimal substrate `detect_config_reads`/`resolve_uses` need, with no
+    analyzer pipeline involved."""
+    ext_id = f"can://python/app/@external/{module}/{callable_name}"
+    fn = PyCallable(
+        name="f", path="mod.py", signature="mod.f", id="can://python/app/mod.py/f()",
+        body={"1:0": BodyNode(kind="call", callee=ext_id, arguments=list(arguments))},
+    )
+    mod = PyModule(file_path="mod.py", module_name="mod", functions={"f": fn})
+    return PyApplication(
+        symbol_table={"mod.py": mod},
+        external_symbols={ext_id: PyExternalSymbol(id=ext_id, name=callable_name, module=module)},
+        artifacts=artifacts or {},
+    )
 
 
 # --- controller ruling (b): empirical subscript probe -----------------------
@@ -103,28 +149,112 @@ def test_level_one_never_populates_config_uses(tmp_path):
     assert app.config_reads_unresolved == []
 
 
+# --- per-rule regression (carried review item) ------------------------------
+# The pipeline tests above exercise os.getenv and configparser.get; the
+# other five shipped rules get no coverage without these. One hand-built
+# `PyApplication` per rule, matched against `config_use_rules.yml` as-shipped.
+
+def test_os_environ_get_rule_resolves_literal():
+    app = _hand_app(
+        "os.environ", "get", [_literal_arg("DB_HOST")],
+        artifacts=_artifact(".env", "env", "DB_HOST", "env"),
+    )
+    edges, unresolved = resolve_uses(detect_config_reads(app), app)
+    assert unresolved == []
+    (edge,) = edges
+    assert edge.prov == ["literal"]
+    assert edge.dst == app.artifacts[".env"].config_keys[0].id
+
+
+def test_dotenv_get_key_rule_resolves_literal():
+    # key_arg=1: dotenv.get_key(dotenv_path, key_to_get).
+    app = _hand_app(
+        "dotenv", "get_key",
+        [_literal_arg(".env"), _literal_arg("DB_HOST")],
+        artifacts=_artifact(".env", "env", "DB_HOST", "env"),
+    )
+    edges, unresolved = resolve_uses(detect_config_reads(app), app)
+    assert unresolved == []
+    (edge,) = edges
+    assert edge.prov == ["literal"]
+
+
+def test_configparser_getint_rule_resolves_literal():
+    # key_arg=1, kwarg="option": cp.getint(section, option).
+    app = _hand_app(
+        "configparser", "getint",
+        [_literal_arg("db"), _literal_arg("port")],
+        artifacts=_artifact("app.ini", "ini", "db.port", "ini"),
+    )
+    edges, unresolved = resolve_uses(detect_config_reads(app), app)
+    assert unresolved == []
+    (edge,) = edges
+    assert edge.prov == ["literal"]
+
+
+def test_configparser_getfloat_rule_resolves_literal():
+    app = _hand_app(
+        "configparser", "getfloat",
+        [_literal_arg("db"), _literal_arg("timeout")],
+        artifacts=_artifact("app.ini", "ini", "db.timeout", "ini"),
+    )
+    edges, unresolved = resolve_uses(detect_config_reads(app), app)
+    assert unresolved == []
+    (edge,) = edges
+    assert edge.prov == ["literal"]
+
+
+def test_configparser_getboolean_rule_resolves_literal():
+    app = _hand_app(
+        "configparser", "getboolean",
+        [_literal_arg("db"), _literal_arg("debug")],
+        artifacts=_artifact("app.ini", "ini", "db.debug", "ini"),
+    )
+    edges, unresolved = resolve_uses(detect_config_reads(app), app)
+    assert unresolved == []
+    (edge,) = edges
+    assert edge.prov == ["literal"]
+
+
+# --- rules loader ------------------------------------------------------------
+
+def test_kwarg_must_be_a_string(tmp_path):
+    """Carried review item: `kwarg` is stored (not yet actionable, per
+    `Rule.kwarg`'s comment) but was never type-checked -- a non-string value
+    would silently ride into a `Rule` instead of failing the load."""
+    bad = tmp_path / "bad.yml"
+    bad.write_text(
+        "version: 1\n"
+        "rules:\n"
+        "  - id: bad\n"
+        "    module: m\n"
+        "    callable: f\n"
+        "    key_arg: 0\n"
+        "    kwarg: 3\n"
+        "    namespaces: [env]\n"
+    )
+    with pytest.raises(ConfigUseRulesError, match="kwarg"):
+        load_rules(bad)
+
+
 # --- namespace preference ------------------------------------------------
 
-def test_namespace_preference_ini_before_properties(tmp_path):
-    app = _app(
-        tmp_path, "namespace",
-        "import configparser\n\n"
-        "def read_option():\n"
-        "    cp = configparser.ConfigParser()\n"
-        "    return cp.get('db', 'host')\n",
-        {
-            "app.ini": "[db]\nhost = ini-value\n",
-            "app.properties": "host=props-value\n",
+def test_namespace_preference_ini_before_properties():
+    app = _hand_app(
+        "configparser", "get", [_literal_arg("db"), _literal_arg("host")],
+        artifacts={
+            **_artifact("app.ini", "ini", "db.host", "ini"),
+            **_artifact("app.properties", "properties", "host", "properties"),
         },
     )
     ini_key = app.artifacts["app.ini"].config_keys[0]
     props_key = app.artifacts["app.properties"].config_keys[0]
-    assert ini_key.key == "db.host" and ini_key.namespace == "ini"
-    assert props_key.key == "host" and props_key.namespace == "properties"
 
-    assert app.config_reads_unresolved == []
-    (edge,) = app.config_uses
+    edges, unresolved = resolve_uses(detect_config_reads(app), app)
+    assert unresolved == []
+    (edge,) = edges
     assert edge.dst == ini_key.id
+    assert edge.dst != props_key.id
     assert edge.prov == ["literal"]
 
 

--- a/test/test_dataflow_sdg.py
+++ b/test/test_dataflow_sdg.py
@@ -13,7 +13,7 @@ import pytest
 
 from pathlib import Path
 
-from codeanalyzer.dataflow.builder import build_program_graphs
+from codeanalyzer.dataflow.builder import _callable_index, build_program_graphs
 from codeanalyzer.dataflow.sdg import CAPTURE_PREFIX, GLOBAL_PREFIX
 from codeanalyzer.options import AnalysisOptions
 from codeanalyzer.core import Codeanalyzer
@@ -23,9 +23,14 @@ FIXTURE = Path(__file__).parent / "fixtures" / "single_functionalities" / "dataf
 
 @pytest.fixture(scope="module")
 def fixture_app(tmp_path_factory):
+    """-a 2, not -a 1: build_program_graphs's callsite phase prefers each
+    site's L2-backfilled BodyNode.callee over Jedi's own callee_signature
+    side channel (builder.py), so it needs backfill_callees to have actually
+    run. -a 1-only SDG construction was never a real product path anyway --
+    core.py calls build_program_graphs at >=4 only, always past the L2 gate."""
     cache = tmp_path_factory.mktemp("dataflow-cache")
     options = AnalysisOptions(
-        input=FIXTURE, analysis_level=1, no_venv=True, cache_dir=cache
+        input=FIXTURE, analysis_level=2, no_venv=True, cache_dir=cache
     )
     with Codeanalyzer(options) as analyzer:
         return analyzer.analyze().application
@@ -185,3 +190,44 @@ def test_assembly_is_deterministic(fixture_app):
         assert [
             (p.id, p.kind, p.var) for p in a.functions[sig].param_nodes
         ] == [(p.id, p.kind, p.var) for p in b.functions[sig].param_nodes]
+
+
+# ------------------------------------------------------- Jedi side-channel gap
+
+
+def test_sdg_survives_when_jedi_side_channel_is_dark(fixture_app):
+    """Regression: build_program_graphs's callsite phase must not depend on
+    Jedi's callee_signature staying populated. Under cross-test parso/Jedi
+    cache pressure that side channel can silently degrade -- observed as the
+    SUMMARY/PARAM_OUT stitching below disappearing only in a full-suite run,
+    never standalone. builder.py now prefers each site's L2-backfilled
+    BodyNode.callee (Jedi filtered the same way, PLUS the defuse linker's
+    fallback -- l2_callees.py) and only falls through to callee_signature
+    when the body has no answer.
+
+    Deep-copies fixture_app (never mutates the shared module-scoped fixture,
+    which every other test in this file also reads) and strips every call
+    site's callee_signature to simulate the side channel going fully dark --
+    the deterministic body-callee path must carry the graph alone.
+    """
+    app = fixture_app.model_copy(deep=True)
+    for c in _callable_index(app).values():
+        for cs in c.call_sites or []:
+            cs.callee_signature = None
+
+    ir = build_program_graphs(app)
+
+    drive = _sig(ir, "drive")
+    summaries = [
+        e for e in ir.sdg_edges
+        if e.type == "SUMMARY" and e.source_sig == drive and e.target_sig == drive
+    ]
+    assert summaries, "no SUMMARY edge at drive's chain_a callsite with callee_signature dark"
+
+    bump = _sig(ir, "bump")
+    out_edges = [
+        e for e in ir.sdg_edges
+        if e.type == "PARAM_OUT" and e.source_sig == bump and e.target_sig == drive
+        and (e.var or "").startswith(GLOBAL_PREFIX)
+    ]
+    assert out_edges, "bump's global write does not reach drive with callee_signature dark"

--- a/test/test_neo4j_config_use.py
+++ b/test/test_neo4j_config_use.py
@@ -1,0 +1,124 @@
+"""Task 4 (#162): PY_USES_CONFIG and PY_READS_CONFIG_UNRESOLVED in the Neo4j
+projection. Mirrors test_neo4j_config_keys.py's idioms: a catalog assertion
+first, then small real-pipeline projects run through `project()`.
+
+Every functional test analyzes at `-a 2` -- the literal tier's minimum level
+-- deliberately, not `-a 4`. A `config_uses`/`config_reads_unresolved` entry's
+`src`/`site` names a call site's body node, and call nodes enter `body` at L1
+(before any config_use tier runs) -- so the src is already a projected
+:PyBodyNode row even at the lowest level config_use can produce an edge,
+independent of the separate fact that the real CLI always forces `-a 4` for
+`--emit neo4j`. Running these tests at `-a 2` proves the no-dangling property
+holds on its own merits rather than riding on that CLI floor.
+"""
+from codeanalyzer.core import Codeanalyzer
+from codeanalyzer.neo4j.project import project
+from codeanalyzer.neo4j.schema import REL_TYPES
+from codeanalyzer.options import AnalysisOptions
+from codeanalyzer.schema.assign_ids import assign_ids
+
+
+def test_catalog_has_config_use_rels():
+    rels = {r.type: r for r in REL_TYPES}
+    uses = rels["PY_USES_CONFIG"]
+    assert uses.from_labels == ["PyBodyNode"] and uses.to_labels == ["ConfigKey"]
+    assert uses.properties == {"prov": "string[]"}
+
+    unresolved = rels["PY_READS_CONFIG_UNRESOLVED"]
+    assert unresolved.from_labels == ["PyApplication"] and unresolved.to_labels == ["PyExternal"]
+    assert unresolved.properties == {
+        "key": "string", "reason": "string", "prov": "string[]", "_k": "string",
+    }
+
+
+def _analyze(proj, tmp_path, **opts):
+    return Codeanalyzer(AnalysisOptions(
+        input=proj, analysis_level=2, no_venv=True, cache_dir=tmp_path / "c", **opts,
+    )).analyze().application
+
+
+def test_resolved_config_use_edge_projected_onto_existing_body_node(tmp_path):
+    proj = tmp_path / "p"
+    proj.mkdir()
+    (proj / "mod.py").write_text(
+        "import os\n\ndef read_host():\n    return os.getenv('DB_HOST')\n"
+    )
+    (proj / ".env").write_text("DB_HOST=example.com\n")
+    app = _analyze(proj, tmp_path)
+    (edge,) = app.config_uses
+
+    rows = project(app, "p", assign_ids(app, "p"))
+    (row,) = [e for e in rows.edges if e.type == "PY_USES_CONFIG"]
+    assert row.from_ref.label == "PyBodyNode" and row.from_ref.value == edge.src
+    assert row.to_ref.label == "ConfigKey" and row.to_ref.value == edge.dst
+    assert row.props == {"prov": ["literal"]}
+
+    # the src id must resolve to an actual projected PyBodyNode row, not a
+    # dangling reference off some other node's merge key.
+    assert any(
+        n.labels[0] == "PyBodyNode" and n.value == edge.src for n in rows.nodes
+    ), "PY_USES_CONFIG.src does not match any projected PyBodyNode"
+
+
+def test_undefined_key_read_projects_as_ghost_edge_with_key_and_reason(tmp_path):
+    proj = tmp_path / "p"
+    proj.mkdir()
+    (proj / "mod.py").write_text(
+        "import os\n\ndef read_missing():\n    return os.getenv('MISSING')\n"
+    )
+    (proj / ".env").write_text("DB_HOST=example.com\n")
+    app = _analyze(proj, tmp_path)
+    (read,) = app.config_reads_unresolved
+
+    rows = project(app, "p", assign_ids(app, "p"))
+    (row,) = [e for e in rows.edges if e.type == "PY_READS_CONFIG_UNRESOLVED"]
+    assert row.from_ref.label == "PyApplication" and row.from_ref.value == "p"
+    assert row.to_ref.label == "PySymbol" and row.to_ref.value == read.callee
+    assert row.props == {"key": "MISSING", "reason": "undefined-key", "prov": ["literal"]}
+    assert row.key == "MISSING|undefined-key"
+
+    assert any(
+        "PyExternal" in n.labels and n.value == read.callee for n in rows.nodes
+    ), "PY_READS_CONFIG_UNRESOLVED ghost target was never projected as :PyExternal"
+
+
+def test_non_literal_read_omits_key_prop(tmp_path):
+    proj = tmp_path / "p"
+    proj.mkdir()
+    (proj / "mod.py").write_text(
+        "import os\n\ndef read_dynamic(kvar):\n    return os.getenv(kvar)\n"
+    )
+    app = _analyze(proj, tmp_path)
+    rows = project(app, "p", assign_ids(app, "p"))
+    (row,) = [e for e in rows.edges if e.type == "PY_READS_CONFIG_UNRESOLVED"]
+    assert "key" not in row.props
+    assert row.props["reason"] == "non-literal"
+    assert row.key == "|non-literal"
+
+
+def test_two_unresolved_reads_same_callee_different_key_both_survive_merge(tmp_path):
+    """Regression: without a relationship discriminant, two distinct
+    undefined-key reads through the SAME external callee (`os.getenv`) would
+    MERGE onto one relationship at load time and one key's finding would be
+    silently overwritten on SET -- the same failure class PY_DDG's `_k` guards
+    against for per-variable dependence edges."""
+    proj = tmp_path / "p"
+    proj.mkdir()
+    (proj / "mod.py").write_text(
+        "import os\n\n"
+        "def read_one():\n    return os.getenv('MISSING_ONE')\n\n"
+        "def read_two():\n    return os.getenv('MISSING_TWO')\n"
+    )
+    (proj / ".env").write_text("DB_HOST=example.com\n")
+    app = _analyze(proj, tmp_path)
+    assert len(app.config_reads_unresolved) == 2
+
+    rows = project(app, "p", assign_ids(app, "p"))
+    unresolved_edges = [e for e in rows.edges if e.type == "PY_READS_CONFIG_UNRESOLVED"]
+    assert len(unresolved_edges) == 2
+    assert {e.props["key"] for e in unresolved_edges} == {"MISSING_ONE", "MISSING_TWO"}
+    assert {e.key for e in unresolved_edges} == {
+        "MISSING_ONE|undefined-key", "MISSING_TWO|undefined-key",
+    }
+    # both hang off the SAME :PyExternal ghost (one os.getenv external symbol)
+    assert len({e.to_ref.value for e in unresolved_edges}) == 1


### PR DESCRIPTION
Closes #162.

Implements `docs/design/specs/2026-08-28-config-use-edge-design.md` — the bridge between the artifact layer's two shores: **which statement reads which configuration key**, level-graded and deterministic.

## What lands

- **`PyCallArgument.value` + `.name`** (L1): JSON-encoded constant capture and bare-identifier capture on every call argument — the literal tier's evidence and the dataflow tier's join variable.
- **Three detection tiers, never guessing** (`application.config_uses`, Neo4j `PY_USES_CONFIG`):
  - *literal* (`-a 2`): detector-table call sites (os.environ/getenv, dotenv, configparser — shipped `config_use_rules.yml` with per-entry namespace preference) with string-literal keys;
  - *dataflow intra* (`-a 3`): non-literal keys whose DDG chain closes over exactly one literal (ssa edges only — alias widening filtered by design);
  - *dataflow interprocedural* (`-a 4`): parameters whose every visible caller agrees on one literal, guarded against local shadowing and invisible callers.
  Superset-monotonic (`-a 2 ⊆ 3 ⊆ 4`, CI-gated); chains that don't close stay **unresolved, never guessed**.
- **`application.config_reads_unresolved`** (Neo4j `PY_READS_CONFIG_UNRESOLVED`, `_k`-discriminated): every detector hit with a statically-unknown key (`non-literal`) or a key nobody defines (`undefined-key`) — the hygiene signal.
- **SDG hardening surfaced by this branch**: `build_program_graphs` now resolves callsites from L2-backfilled body callees (deterministic, linker-backed) instead of Jedi's cache-sensitive side channel — a pre-existing product fragility exposed by suite-order cache pressure, root-caused by bisect, fixed with a regression test that strips the Jedi channel entirely and demands the SDG survive.

## Verification

10 commits, 5 TDD tasks, per-task reviews with fix rounds, final whole-branch review (2 HIGH spec-contract violations caught by reviewer probes — monotonicity break via alias widening, never-guess violation via conditional shadowing — both fixed with RED-then-GREEN regressions), scoped re-review clean with independent live probes. Full suite **451 passed / 6 skipped**, reproduced solo three times.

Stacked on #163; merge order #158 → #160 → #161 → #163 → this.
