### PR TITLE
fix(test): build the slicing fixture at level 2

### DIFF
--- a/test/test_dataflow_slicing.py
+++ b/test/test_dataflow_slicing.py
@@ -20,7 +20,10 @@ FIXTURE = Path(__file__).parent / "fixtures" / "single_functionalities" / "dataf
 def ir(tmp_path_factory):
     cache = tmp_path_factory.mktemp("dataflow-slice-cache")
     options = AnalysisOptions(
-        input=FIXTURE, analysis_level=1, no_venv=True, cache_dir=cache
+        # Level 2: the SDG builder resolves callsites from L2-backfilled body
+        # callees (deterministic); at level 1 it would fall back to Jedi's
+        # cache-sensitive side channel (same fragility fixed for test_dataflow_sdg).
+        input=FIXTURE, analysis_level=2, no_venv=True, cache_dir=cache
     )
     with Codeanalyzer(options) as analyzer:
         return build_program_graphs(analyzer.analyze().application)


### PR DESCRIPTION
Same order-dependence class the SDG tests had (fixed in #164's round 2): `test_dataflow_slicing.py` still analyzed the shared dataflow fixture at level 1, so `build_program_graphs` fell back to Jedi's cache-sensitive side channel — standalone green, full-suite red under cumulative cache pressure (reproduced on merged main: 2 failed/449). Level 2 gives the builder deterministic linker-backed body callees. One-line fix plus comment.