### PR TITLE
feat: deployment-env config keys — Dockerfile ENV/ARG, compose and k8s env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Unresolved reads (non-literal keys, undefined keys) emitted in
   `application.config_reads_unresolved` with reasons; `PY_READS_CONFIG_UNRESOLVED`
   Neo4j projection (#162).
+- Deployment-env config-key namespaces: Dockerfile `ENV`/`ARG` directives
+  (multi-key, legacy space form, backslash continuations, quoted values) and
+  compose/k8s `environment`/`env` shapes are now extracted too. `ENV` and
+  compose/k8s `environment`/`env` entries mint namespace `env`, so
+  `os.environ`/`os.getenv` reads resolve against deployment-declared
+  variables; Dockerfile `ARG` mints its own `dockerfile` namespace
+  (build-time only, not env-detector-bindable). Compose/k8s recognition
+  dual-mints alongside the plain `yaml` dotted-path keys, by design (#165).
 
 ## [1.2.0] - 2026-08-26
 

--- a/codeanalyzer/artifacts/config_keys.py
+++ b/codeanalyzer/artifacts/config_keys.py
@@ -26,13 +26,19 @@ dotted-path shape at any nesting depth, not schema-anchored) shapes mint
 ADDITIONAL namespace-`env` keys keyed on the bare var name, alongside the
 normal namespace-`yaml` dotted-path ones -- dual-minting is intentional
 (so `os.environ`/`os.getenv` reads bind to compose/k8s-declared vars too),
-never deduped away. Ids never collide with the plain yaml mint: the env
-mint's key is always the bare var name while the yaml mint's key always
-carries the full dotted path, so the two differ by construction for every
-shape this pass recognizes. This pass is shape-based, not filename/role
-gated -- any yaml artifact whose content happens to match mints the extra
-keys, matching this module's general overlay posture (permissive, never a
-schema validator).
+never deduped away. The `key` FIELD is always the bare var name (matching
+`env` namespace's exact-match resolution semantics), but the `id` cannot
+reuse that bare name unqualified: a TOP-LEVEL yaml key sharing the same
+name as a recognized env var (e.g. a document with both a bare
+`COMPOSE_ONLY_KEY:` entry and a `services.web.environment.COMPOSE_ONLY_KEY`
+one) would otherwise collide with the plain yaml mint's own bare-key id --
+the yaml mint's key is USUALLY a longer dotted path that can't collide, but
+not always (a top-level leaf's dotted path IS just its bare name). Same fix
+as the dockerfile ARG case: the env-dual-mint's id is disambiguated with an
+internal `env.` prefix (`_build_keys`'s `id_key`), the `key` field itself
+unaffected. This pass is shape-based, not filename/role gated -- any yaml
+artifact whose content happens to match mints the extra keys, matching this
+module's general overlay posture (permissive, never a schema validator).
 
 Span precision differs by shape: env/properties/ini/dockerfile are
 line-oriented, so the parse itself knows the exact defining line. yaml/
@@ -231,18 +237,30 @@ def _join_continuations(lines: List[str], start_i: int) -> Tuple[str, int]:
 
 
 def _split_ws_respecting_quotes(s: str) -> List[str]:
-    """Whitespace-split `s`, except inside a matching `'`/`"` span (a quoted
-    value may contain spaces) -- quote characters stay IN the returned
-    tokens, stripped afterward by `_env_value` so there is one quote-
-    stripping implementation, not two."""
+    r"""Whitespace-split `s`, except inside a matching `'`/`"` span (a quoted
+    value may contain spaces) or right after an unquoted `\` -- a backslash
+    escapes the next character (`\ ` keeps a literal space in the token
+    instead of splitting there, `\\` collapses to one literal backslash),
+    mirroring Docker's own shell-style ENV splitting (moby's `Rex\ The\
+    Dog` example). A dangling trailing `\` with nothing to escape is kept
+    literally rather than raising -- a real trailing continuation backslash
+    is already stripped upstream by `_join_continuations`, so this is only
+    a defensive fallback. Quote characters stay IN the returned tokens,
+    stripped afterward by `_env_value` so there is one quote-stripping
+    implementation, not two."""
     tokens: List[str] = []
     buf: List[str] = []
     quote: Optional[str] = None
-    for ch in s:
+    i, n = 0, len(s)
+    while i < n:
+        ch = s[i]
         if quote:
             buf.append(ch)
             if ch == quote:
                 quote = None
+        elif ch == "\\":
+            i += 1
+            buf.append(s[i] if i < n else ch)
         elif ch in "'\"":
             quote = ch
             buf.append(ch)
@@ -252,6 +270,7 @@ def _split_ws_respecting_quotes(s: str) -> List[str]:
                 buf = []
         else:
             buf.append(ch)
+        i += 1
     if buf:
         tokens.append("".join(buf))
     return tokens
@@ -262,8 +281,12 @@ def _dockerfile_env_entries(text: str, lines: List[str]) -> List[_Entry]:
     `ENV a=1 b=2`, and the legacy single-key `ENV K v` space form (Docker's
     own disambiguation rule: the token right after `ENV` decides the form --
     a `=` in it means one-or-more `key=value` pairs; no `=` means the
-    legacy form, where the key is the first word and the REST of the line,
-    verbatim, is the value)."""
+    legacy form, where the key is the first word and the REST of the line
+    is the value). The legacy form's value is taken VERBATIM -- unlike the
+    `key=value` form, real Docker does no quote processing there at all
+    (moby's `parseNameVal`), so `ENV NAME "John Doe"` keeps its quotes; the
+    key/value separator is general whitespace (a tab is as legal as a
+    space), not a literal `" "`."""
     out: List[_Entry] = []
     i, n = 0, len(lines)
     while i < n:
@@ -282,9 +305,9 @@ def _dockerfile_env_entries(text: str, lines: List[str]) -> List[_Entry]:
                 if sep and _ENV_KEY_NAME.match(key):
                     out.append((key, _env_value(raw_val), span))
         else:
-            key, sep, raw_val = rest.partition(" ")
-            if sep and _ENV_KEY_NAME.match(key):
-                out.append((key, _env_value(raw_val.strip()), span))
+            parts = rest.split(None, 1)
+            if len(parts) == 2 and _ENV_KEY_NAME.match(parts[0]):
+                out.append((parts[0], parts[1], span))
         i += 1
     return out
 
@@ -454,10 +477,14 @@ def _build_keys(
     bool/None that needs that coercion.
 
     `id_key` remaps `dotted_key` for ID CONSTRUCTION only -- the `.key` FIELD
-    always stays the bare `dotted_key`. Used solely so a Dockerfile ARG's id
-    can't collide with an ENV of the same name minting the same bare-name id
-    in the "env" namespace (`ARG X` then `ENV X=$X` is a common promotion
-    idiom); every other namespace omits it, preserving today's id shape."""
+    always stays the bare `dotted_key`. Two call sites need it, both to keep
+    a bare-name mint from colliding with another mint that happens to use
+    the same bare name for its OWN id: a Dockerfile ARG's id (`ARG X` then
+    `ENV X=$X` is a common promotion idiom -- both would otherwise mint id
+    `.../@key/X`), and a yaml artifact's compose/k8s env-dual-mint id (a
+    top-level yaml key sharing a name with a recognized env var would
+    otherwise collide with the plain yaml mint's own bare-key id). Every
+    other namespace omits it, preserving today's id shape."""
     coalesced: Dict[str, Tuple[object, Optional[Span]]] = {}
     for dotted_key, value, span in entries:
         coalesced[dotted_key] = (value, span)
@@ -545,7 +572,10 @@ def extract_config_keys(
             ]
             keys = (
                 _build_keys(artifact.id, "yaml", _parse_yaml(full_text, lines), capture_value)
-                + _build_keys(artifact.id, "env", env_entries, capture_value)
+                + _build_keys(
+                    artifact.id, "env", env_entries, capture_value,
+                    id_key=lambda k: f"env.{k}",
+                )
             )
         else:
             parser = _NAMESPACE_PARSERS.get(artifact.format)

--- a/codeanalyzer/artifacts/config_keys.py
+++ b/codeanalyzer/artifacts/config_keys.py
@@ -1,18 +1,51 @@
-"""Config-key flatteners (#152). Pure text-in/records-out, mirroring
+"""Config-key flatteners (#152, #165). Pure text-in/records-out, mirroring
 `artifacts/parsers.py`'s idiom: one dispatcher over per-format internals,
 never raising.
 
 Namespace dispatch: an env-family basename (`.env`, `.env.*`, `.flaskenv`)
 always wins, regardless of the artifact's declared `format`; otherwise the
-`format` field selects yaml/json/toml/ini/properties. Any other format
-extracts nothing (not a failure -- there's just nothing to flatten).
+`format` field selects yaml/json/toml/ini/properties/dockerfile. Any other
+format extracts nothing (not a failure -- there's just nothing to flatten).
 
-Span precision differs by shape: env/properties/ini are line-oriented, so
-the parse itself knows the exact defining line. yaml/json/toml are
-tree-shaped -- span recovery falls back to a best-effort search for the
-final dotted-key segment on its own line (see `_find_key_span`), which can
-bind the wrong line when the same leaf name recurs at another nesting level,
-or find nothing at all (`span=None`) for a minified/single-line file.
+Deployment-env namespaces (#165): a `dockerfile`-format artifact mints TWO
+namespaces from one file -- `ENV K=v` directives mint namespace `env` (the
+whole point is that `os.environ`/`os.getenv` reads, whose detector rule
+prefers namespace `env`, bind to them), `ARG K[=default]` directives mint
+namespace `dockerfile` (build-time only, deliberately not bindable by the
+env detectors). Both share the bare var name as `key`, so an `ARG X` later
+promoted via `ENV X=$X` -- a common idiom -- would collide on `id` (`key`
+alone determines it) if both used the plain id shape; the `dockerfile`
+mint's id is disambiguated with an internal `arg.` prefix (the `key` FIELD
+stays the bare name either way, since nothing about resolution or the
+issue's contract cares how the id looks).
+
+A `yaml`-format artifact ALSO gets a supplementary recognition pass after
+the normal dotted-path flattening: well-known compose (`services.<name>.
+environment` map/list) and k8s (`...env.<idx>.name`/`.value`, matched as a
+dotted-path shape at any nesting depth, not schema-anchored) shapes mint
+ADDITIONAL namespace-`env` keys keyed on the bare var name, alongside the
+normal namespace-`yaml` dotted-path ones -- dual-minting is intentional
+(so `os.environ`/`os.getenv` reads bind to compose/k8s-declared vars too),
+never deduped away. Ids never collide with the plain yaml mint: the env
+mint's key is always the bare var name while the yaml mint's key always
+carries the full dotted path, so the two differ by construction for every
+shape this pass recognizes. This pass is shape-based, not filename/role
+gated -- any yaml artifact whose content happens to match mints the extra
+keys, matching this module's general overlay posture (permissive, never a
+schema validator).
+
+Span precision differs by shape: env/properties/ini/dockerfile are
+line-oriented, so the parse itself knows the exact defining line. yaml/
+json/toml are tree-shaped -- span recovery falls back to a best-effort
+search for the final dotted-key segment on its own line (see
+`_find_key_span`), which can bind the wrong line when the same leaf name
+recurs at another nesting level, or find nothing at all (`span=None`) for
+a minified/single-line file. The compose/k8s env-recognition mint reuses
+this same best-effort search keyed on the bare var name: it finds the
+defining line for compose's map/list forms (`KEY:`/`KEY=` is the var's own
+line) but not k8s's name/value list shape (the var name is a VALUE on a
+`name:` line, not a key label there) -- k8s env-mint spans are `None`,
+an accepted extension of the existing best-effort gap.
 """
 from __future__ import annotations
 
@@ -94,9 +127,46 @@ def _parse_toml(text: str, lines: List[str]) -> List[_Entry]:
     return _flatten_structured(tomllib.loads(text), text, lines)
 
 
+# --- compose/k8s env recognition (#165): supplemental namespace="env" mint
+# over the SAME flattened (dotted_key, value) pairs the "yaml" namespace
+# uses -- see the module docstring for why dual-minting is safe and
+# intentional. Shape-matched on the dotted path string, not the yaml tree,
+# so both recognizers stay simple regex-over-strings, symmetric with the
+# rest of this module's line/path-oriented parsing. -------------------------
+
+_K8S_ENV_NAME = re.compile(r'(?:^|\.)env\.\d+\.name$')
+_COMPOSE_ENV = re.compile(r'^services\.[^.]+\.environment\.(.+)$')
+
+
+def _recognize_env_shapes(flat: List[Tuple[str, object]]) -> List[Tuple[str, object]]:
+    """`(key, value)` pairs for every compose/k8s env shape found in `flat`
+    (the same `_flatten(data)` pairs the "yaml" namespace flattens) --
+    NOT dotted paths, the bare var name, matching `env` namespace semantics
+    (`config_use.py` resolves that namespace by exact `key ==` match)."""
+    by_path = dict(flat)
+    out: List[Tuple[str, object]] = []
+    for dotted_key, value in flat:
+        if _K8S_ENV_NAME.search(dotted_key):
+            sibling = dotted_key[: -len("name")] + "value"  # ...env.<idx>.value
+            out.append((_stringify(value), by_path.get(sibling)))
+            continue
+        m = _COMPOSE_ENV.match(dotted_key)
+        if not m:
+            continue
+        tail = m.group(1)
+        if _ENV_KEY_NAME.match(tail):  # map form: tail IS the var name
+            out.append((tail, value))
+        elif tail.isdigit():  # list form: leaf is "KEY=val" or bare "KEY"
+            key, sep, val = _stringify(value).partition("=")
+            if _ENV_KEY_NAME.match(key):
+                out.append((key, val if sep else None))
+    return out
+
+
 # --- env: KEY=value, `#` comments, `export ` prefix, quote stripping -------
 
 _ENV_LINE = re.compile(r'^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$')
+_ENV_KEY_NAME = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')  # shared: dockerfile + compose/k8s recognition
 
 
 def _env_value(raw: str) -> str:
@@ -130,6 +200,116 @@ def _parse_env(text: str, lines: List[str]) -> List[_Entry]:
             continue
         key, value = m.group(1), _env_value(m.group(2))
         out.append((key, value, _line_span(text, lines, lineno)))
+    return out
+
+
+# --- dockerfile: `ENV`/`ARG` directives (#165). Line-based, case-insensitive
+# instruction keywords (Dockerfile convention is uppercase, the spec itself
+# is not case-sensitive); no BuildKit heredoc awareness in v1 -- a heredoc
+# body line is just another line that doesn't match `_DOCKER_ENV`/`_DOCKER_ARG`
+# and is silently skipped, same as any other unparseable line (overlay
+# posture). Multi-stage `FROM ... AS x` scoping is not modeled -- every
+# ENV/ARG in the file is scanned regardless of which stage it's in. --------
+
+_DOCKER_ENV = re.compile(r'^ENV\s+(.*)$', re.IGNORECASE)
+_DOCKER_ARG = re.compile(r'^ARG\s+(.*)$', re.IGNORECASE)
+
+
+def _join_continuations(lines: List[str], start_i: int) -> Tuple[str, int]:
+    """From `lines[start_i]`, join any backslash-continued following lines
+    into one logical instruction line -- same trailing-backslash-drop +
+    leading/trailing-whitespace-strip join `_parse_properties` already uses
+    for its own continuations. Returns `(joined_text, index of the LAST
+    line consumed)`."""
+    i, n = start_i, len(lines)
+    parts = [lines[i].strip()]
+    while parts[-1].endswith("\\") and i + 1 < n:
+        parts[-1] = parts[-1][:-1]  # drop just the continuation backslash
+        i += 1
+        parts.append(lines[i].strip())
+    return "".join(parts), i
+
+
+def _split_ws_respecting_quotes(s: str) -> List[str]:
+    """Whitespace-split `s`, except inside a matching `'`/`"` span (a quoted
+    value may contain spaces) -- quote characters stay IN the returned
+    tokens, stripped afterward by `_env_value` so there is one quote-
+    stripping implementation, not two."""
+    tokens: List[str] = []
+    buf: List[str] = []
+    quote: Optional[str] = None
+    for ch in s:
+        if quote:
+            buf.append(ch)
+            if ch == quote:
+                quote = None
+        elif ch in "'\"":
+            quote = ch
+            buf.append(ch)
+        elif ch.isspace():
+            if buf:
+                tokens.append("".join(buf))
+                buf = []
+        else:
+            buf.append(ch)
+    if buf:
+        tokens.append("".join(buf))
+    return tokens
+
+
+def _dockerfile_env_entries(text: str, lines: List[str]) -> List[_Entry]:
+    """`ENV` directives -> `(KEY, value, span)`. Handles `ENV K=v`, multi-key
+    `ENV a=1 b=2`, and the legacy single-key `ENV K v` space form (Docker's
+    own disambiguation rule: the token right after `ENV` decides the form --
+    a `=` in it means one-or-more `key=value` pairs; no `=` means the
+    legacy form, where the key is the first word and the REST of the line,
+    verbatim, is the value)."""
+    out: List[_Entry] = []
+    i, n = 0, len(lines)
+    while i < n:
+        stripped = lines[i].strip()
+        if not stripped or stripped.startswith("#") or not _DOCKER_ENV.match(stripped):
+            i += 1
+            continue
+        start_lineno = i + 1
+        joined, i = _join_continuations(lines, i)
+        rest = _DOCKER_ENV.match(joined).group(1).strip()
+        span = _line_span(text, lines, start_lineno)
+        first_token = rest.split(None, 1)[0] if rest else ""
+        if "=" in first_token:
+            for tok in _split_ws_respecting_quotes(rest):
+                key, sep, raw_val = tok.partition("=")
+                if sep and _ENV_KEY_NAME.match(key):
+                    out.append((key, _env_value(raw_val), span))
+        else:
+            key, sep, raw_val = rest.partition(" ")
+            if sep and _ENV_KEY_NAME.match(key):
+                out.append((key, _env_value(raw_val.strip()), span))
+        i += 1
+    return out
+
+
+def _dockerfile_arg_entries(text: str, lines: List[str]) -> List[_Entry]:
+    """`ARG KEY[=default]` -> `(KEY, value, span)`; no `=default` means
+    `value=None` (#165's ARG semantics -- distinct from `_stringify`'s "" for
+    a modeled null elsewhere in this module: an ARG default that is simply
+    ABSENT is not the same fact as a key explicitly set to an empty value)."""
+    out: List[_Entry] = []
+    i, n = 0, len(lines)
+    while i < n:
+        stripped = lines[i].strip()
+        if not stripped or stripped.startswith("#") or not _DOCKER_ARG.match(stripped):
+            i += 1
+            continue
+        start_lineno = i + 1
+        joined, i = _join_continuations(lines, i)
+        rest = _DOCKER_ARG.match(joined).group(1).strip()
+        span = _line_span(text, lines, start_lineno)
+        key, sep, raw_default = rest.partition("=")
+        key = key.strip()
+        if _ENV_KEY_NAME.match(key):
+            out.append((key, _env_value(raw_default) if sep else None, span))
+        i += 1
     return out
 
 
@@ -259,16 +439,50 @@ def _stringify(value: object) -> str:
     return str(value)
 
 
+def _build_keys(
+    artifact_id: str, namespace: str, entries: List[_Entry], capture_value: bool,
+    *, raw_value: bool = False, id_key: Optional[Callable[[str], str]] = None,
+) -> List[PyConfigKey]:
+    """Coalesce `entries` (last dotted-key occurrence in file order wins --
+    the existing L1 duplicate-key precedent, e.g. a redefined env var) into
+    `PyConfigKey` records for one namespace.
+
+    `raw_value=True` (dockerfile) passes the parsed value straight through
+    instead of `_stringify`-ing it, so an ARG's absent default surfaces as
+    `value=None` rather than `_stringify`'s "" for a modeled null -- dockerfile
+    values are already plain parsed text/`None`, never a yaml/json/toml
+    bool/None that needs that coercion.
+
+    `id_key` remaps `dotted_key` for ID CONSTRUCTION only -- the `.key` FIELD
+    always stays the bare `dotted_key`. Used solely so a Dockerfile ARG's id
+    can't collide with an ENV of the same name minting the same bare-name id
+    in the "env" namespace (`ARG X` then `ENV X=$X` is a common promotion
+    idiom); every other namespace omits it, preserving today's id shape."""
+    coalesced: Dict[str, Tuple[object, Optional[Span]]] = {}
+    for dotted_key, value, span in entries:
+        coalesced[dotted_key] = (value, span)
+    keys = []
+    for dotted_key, (value, span) in coalesced.items():
+        text_value = value if raw_value else _stringify(value)
+        keys.append(PyConfigKey(
+            id=config_key_id(artifact_id, id_key(dotted_key) if id_key else dotted_key),
+            key=dotted_key, namespace=namespace,
+            value=text_value if capture_value else None,
+            span=span, references=_find_references(text_value or ""),
+        ))
+    return keys
+
+
 # --- public API -----------------------------------------------------------
 
 def is_config_eligible(artifact: PyArtifact) -> bool:
     """Whether `artifact` is worth extracting config keys from: an env-family
-    basename (`.env`/`.env.*`/`.flaskenv`, regardless of declared format), or
-    a namespace-bearing format (yaml/json/toml/ini/properties). A binary
-    artifact is never eligible -- there is no decodable text to flatten, and
-    a rule-matched-but-undecodable file downgrades to `format="binary"`
-    regardless of its basename (see discovery.py), so the binary check wins
-    even over an env-family name.
+    basename (`.env`/`.env.*`/`.flaskenv`, regardless of declared format), a
+    `dockerfile`-format artifact (#165), or a namespace-bearing format
+    (yaml/json/toml/ini/properties). A binary artifact is never eligible --
+    there is no decodable text to flatten, and a rule-matched-but-undecodable
+    file downgrades to `format="binary"` regardless of its basename (see
+    discovery.py), so the binary check wins even over an env-family name.
 
     Callers (core.py's wiring) use this to skip the on-disk read + parse
     attempt entirely on artifacts that can never yield config keys, rather
@@ -277,7 +491,11 @@ def is_config_eligible(artifact: PyArtifact) -> bool:
     if artifact.format == "binary":
         return False
     basename = artifact.path.rsplit("/", 1)[-1]
-    return _is_env_family(basename) or artifact.format in _NAMESPACE_PARSERS
+    return (
+        _is_env_family(basename)
+        or artifact.format == "dockerfile"
+        or artifact.format in _NAMESPACE_PARSERS
+    )
 
 
 def extract_config_keys(
@@ -294,39 +512,46 @@ def extract_config_keys(
     `False` only when parsing raised. Never raises: every code path below is
     covered by one `try`/`except`, so a malformed file degrades to `([],
     False)` instead of an exception escaping to the caller. `keys` is always
-    sorted by `key` (L1 determinism).
+    sorted by `key` (L1 determinism) -- a dockerfile or dual-minted yaml
+    artifact concatenates its namespace groups before this one sort, and
+    Python's sort is stable, so a same-`key` tie across namespaces still
+    resolves deterministically (env before dockerfile; yaml before env).
 
     `value` is populated only when `capture_value` is True; `key`,
     `namespace`, `span`, and `references` are extracted unconditionally
     either way (references are recognized in the raw leaf value regardless
     of whether that value is exposed)."""
     basename = artifact.path.rsplit("/", 1)[-1]
-    if _is_env_family(basename):
-        namespace, parser = "env", _parse_env
-    else:
-        parser = _NAMESPACE_PARSERS.get(artifact.format)
-        if parser is None:
-            return [], True
-        namespace = artifact.format
-
     try:
         lines = full_text.splitlines()
-        entries = parser(full_text, lines)
-        # Last occurrence wins on a duplicate dotted key (env/properties can
-        # legally redefine a key later in the file; a repeat would otherwise
-        # collide on `id`, which is derived from `key` alone).
-        coalesced: Dict[str, Tuple[object, Optional[Span]]] = {}
-        for dotted_key, value, span in entries:
-            coalesced[dotted_key] = (value, span)
-        keys = [
-            PyConfigKey(
-                id=config_key_id(artifact.id, dotted_key), key=dotted_key,
-                namespace=namespace,
-                value=_stringify(value) if capture_value else None,
-                span=span, references=_find_references(_stringify(value)),
+        if _is_env_family(basename):
+            keys = _build_keys(artifact.id, "env", _parse_env(full_text, lines), capture_value)
+        elif artifact.format == "dockerfile":
+            keys = _build_keys(
+                artifact.id, "env", _dockerfile_env_entries(full_text, lines), capture_value,
+                raw_value=True,
+            ) + _build_keys(
+                artifact.id, "dockerfile", _dockerfile_arg_entries(full_text, lines), capture_value,
+                raw_value=True, id_key=lambda k: f"arg.{k}",
             )
-            for dotted_key, (value, span) in coalesced.items()
-        ]
+        elif artifact.format == "yaml":
+            # Two independent parses (like every other format here -- each
+            # piece parses what IT needs, no shared-state shortcut): `_parse_
+            # yaml` for the plain dotted-path entries, a second `safe_load`
+            # for the raw tree the env-shape recognizer walks.
+            flat = list(_flatten(yaml.safe_load(full_text) or {}))
+            env_entries = [
+                (k, v, _find_key_span(full_text, lines, k)) for k, v in _recognize_env_shapes(flat)
+            ]
+            keys = (
+                _build_keys(artifact.id, "yaml", _parse_yaml(full_text, lines), capture_value)
+                + _build_keys(artifact.id, "env", env_entries, capture_value)
+            )
+        else:
+            parser = _NAMESPACE_PARSERS.get(artifact.format)
+            if parser is None:
+                return [], True
+            keys = _build_keys(artifact.id, artifact.format, parser(full_text, lines), capture_value)
         keys.sort(key=lambda k: k.key)
         return keys, True
     except Exception:

--- a/codeanalyzer/schema/py_schema.py
+++ b/codeanalyzer/schema/py_schema.py
@@ -492,7 +492,7 @@ class PyConfigKey(BaseModel):
 
     id: str = ""  # <artifact-id>@key/<dotted.key>
     key: str  # dotted path; numeric segments for arrays, e.g. "services.web.ports.0"
-    namespace: str  # env|yaml|json|toml|ini|properties
+    namespace: str  # env|yaml|json|toml|ini|properties|dockerfile
     value: Optional[str] = None  # populated only when options.artifact_text is on
     span: Optional[Span] = None  # into the artifact's source; best-effort for yaml/json/toml
     references: List[str] = []  # raw recognized tokens, order of appearance, deduplicated

--- a/docs/design/specs/2026-08-28-config-key-family-design.md
+++ b/docs/design/specs/2026-08-28-config-key-family-design.md
@@ -25,10 +25,18 @@ reading a key) is the recorded follow-up.
    references are always extracted — `--no-artifact-text` drops values and
    source together, so the secret off-switch actually switches everything off.
 3. **V1 formats**: `env` (`.env`, `.env.*`, `.flaskenv`), `yaml`, `json`,
-   `toml`, `ini`, `properties`. Extraction is format-driven over existing
-   artifacts (pyproject.toml gets keys too; overlap with dependency records is
-   harmless). `references[]` v1 recognizes three syntaxes, recorded as raw
-   tokens: `${VAR}`/`$VAR`, `%(name)s`, `${{ ... }}`.
+   `toml`, `ini`, `properties`, `dockerfile`. Extraction is format-driven over
+   existing artifacts (pyproject.toml gets keys too; overlap with dependency
+   records is harmless). `references[]` v1 recognizes three syntaxes, recorded
+   as raw tokens: `${VAR}`/`$VAR`, `%(name)s`, `${{ ... }}`. Deployment-env
+   namespaces (issue #165, a later extension of this same machinery): a
+   `dockerfile`-format artifact's `ENV` directives mint namespace `env` (so
+   `os.environ`/`os.getenv` reads bind to them) while its `ARG` directives
+   mint namespace `dockerfile` (build-time only, not env-detector-bindable);
+   a `yaml`-format artifact
+   additionally dual-mints namespace `env` keys for recognized compose
+   (`services.*.environment`) and k8s (`...env[].name`/`.value`) shapes,
+   alongside the plain dotted-path `yaml` mint of the same leaves.
 4. **Placement: nested.** `PyArtifact.config_keys: List[PyConfigKey]` —
    containment mirrors `DEFINES_CONFIG`; L1 data, identical at every level.
 5. **Overlay posture.** Parse failure never drops the artifact node; it sets
@@ -43,7 +51,7 @@ reading a key) is the recorded follow-up.
 | --- | --- | --- |
 | `id` | str | `<artifact-id>@key/<dotted.key>` |
 | `key` | str | dotted path; numeric segments for arrays (`services.web.ports.0`) |
-| `namespace` | str | `env` \| `yaml` \| `json` \| `toml` \| `ini` \| `properties` |
+| `namespace` | str | `env` \| `yaml` \| `json` \| `toml` \| `ini` \| `properties` \| `dockerfile` |
 | `value` | Optional[str] | only when text capture on |
 | `span` | Span | into the artifact's source |
 | `references` | List[str] | raw recognized tokens |

--- a/test/fixtures/whole_applications/manifests_app/Dockerfile
+++ b/test/fixtures/whole_applications/manifests_app/Dockerfile
@@ -1,1 +1,4 @@
 FROM python:3.12-slim
+
+ARG BUILD_REV
+ENV APP_MODE=production

--- a/test/fixtures/whole_applications/manifests_app/docker-compose.yml
+++ b/test/fixtures/whole_applications/manifests_app/docker-compose.yml
@@ -1,3 +1,5 @@
 services:
   web:
     build: .
+    environment:
+      COMPOSE_ONLY_KEY: x

--- a/test/fixtures/whole_applications/manifests_app/pkg/config_reader.py
+++ b/test/fixtures/whole_applications/manifests_app/pkg/config_reader.py
@@ -1,4 +1,4 @@
-"""Config-use e2e fixture for all five detection shapes (#162 Task 5)."""
+"""Config-use e2e fixture for all six detection shapes (#162 Task 5, #165)."""
 import os
 
 
@@ -38,3 +38,9 @@ def get_config_multi_def(use_debug):
 # Should appear in config_reads_unresolved with reason: "undefined-key"
 def get_missing_config():
     return os.getenv("NOT_DEFINED_ANYWHERE")
+
+
+# Shape 6: Deployment-env, reads APP_MODE from the Dockerfile ENV directive
+# (#165). Direct literal, resolves at -a 2 like shape 1.
+def get_app_mode():
+    return os.getenv("APP_MODE")

--- a/test/test_artifacts_end_to_end.py
+++ b/test/test_artifacts_end_to_end.py
@@ -205,20 +205,26 @@ def test_config_keys_extraction_level(tmp_path):
     )).analyze().application
 
     # Config keys should be identical at both levels
-    for art_name in [".env", "config/settings.yml", "app.properties"]:
+    for art_name in [
+        ".env", "config/settings.yml", "app.properties",
+        "Dockerfile", "docker-compose.yml",  # deployment-env namespaces (#165)
+    ]:
         l1_keys = sorted([k.key for k in app_l1.artifacts[art_name].config_keys])
         l4_keys = sorted([k.key for k in app_l4.artifacts[art_name].config_keys])
         assert l1_keys == l4_keys
 
 
 def test_config_keys_extraction_full(tmp_path):
-    """Verify extraction='full' on the three config files."""
+    """Verify extraction='full' on the config files, including Dockerfile
+    (newly namespace-eligible as of #165 -- it was "none" before, since
+    `is_config_eligible` used to skip it outright)."""
     app = _app(tmp_path, "extraction_test")
 
-    # All three new config files should have extraction='full'
     assert app.artifacts[".env"].extraction == "full"
     assert app.artifacts["config/settings.yml"].extraction == "full"
     assert app.artifacts["app.properties"].extraction == "full"
+    assert app.artifacts["Dockerfile"].extraction == "full"
+    assert app.artifacts["docker-compose.yml"].extraction == "full"
 
 
 def _id_suffix(id_: str) -> str:
@@ -229,7 +235,8 @@ def _id_suffix(id_: str) -> str:
 
 
 def test_config_uses_full(tmp_path):
-    """Verify config-use edges at -a 4: all five fixture shapes (#162 Task 5).
+    """Verify config-use edges at -a 4: all six fixture shapes (#162 Task 5,
+    #165 shape 6).
 
     Exact-set assertions (the plan's "exact", not a `>=` lower bound): every
     `config_uses` edge as `(src-suffix, dst-key, prov)` and every
@@ -238,7 +245,8 @@ def test_config_uses_full(tmp_path):
     against the dataflow-tier fixes landed alongside this test -- none of
     those fixes' shapes (aliasing, conditional shadowing, module-scope
     callers) occur in this fixture, so the counts are unchanged from the
-    pre-fix reviewer probe: 3 resolved, 2 unresolved at -a 4).
+    pre-fix reviewer probe except for #165's own addition: 4 resolved, 2
+    unresolved at -a 4).
     """
     app = Codeanalyzer(AnalysisOptions(
         input=FIXTURE, analysis_level=4, no_venv=True, cache_dir=tmp_path / "config_uses",
@@ -250,11 +258,14 @@ def test_config_uses_full(tmp_path):
     #    (site is the read INSIDE _read_config, not get_secret_token's call)
     # 4. Multi-def unresolved: get_config_multi_def() -> unresolved (two defs)
     # 5. Undefined-key: get_missing_config() -> unresolved (key not in .env)
+    # 6. Deployment-env literal: get_app_mode() -> os.getenv("APP_MODE"),
+    #    binding to the Dockerfile `ENV APP_MODE=production` key (#165).
     uses = {(_id_suffix(e.src), _id_suffix(e.dst), tuple(e.prov)) for e in app.config_uses}
     assert uses == {
         ("get_database_url()@7:11", "DATABASE_URL", ("literal",)),
         ("get_api_key()@14:11", "API_KEY", ("dataflow",)),
         ("_read_config(name)@20:11", "SECRET_API_TOKEN", ("dataflow",)),
+        ("get_app_mode()@46:11", "APP_MODE", ("literal",)),
     }
 
     unresolved = {(_id_suffix(r.site), r.reason, r.key) for r in app.config_reads_unresolved}
@@ -262,6 +273,40 @@ def test_config_uses_full(tmp_path):
         ("get_config_multi_def(use_debug)@34:11", "non-literal", None),
         ("get_missing_config()@40:11", "undefined-key", "NOT_DEFINED_ANYWHERE"),
     }
+
+
+def test_config_uses_app_mode_resolves_at_l2(tmp_path):
+    """The deployment-env DoD, verified directly (#165): `get_app_mode()`'s
+    `os.getenv("APP_MODE")` binds to the Dockerfile `ENV APP_MODE=production`
+    key at `-a 2` already -- a direct literal, same tier as `DATABASE_URL`,
+    with no dataflow tier needed."""
+    app = Codeanalyzer(AnalysisOptions(
+        input=FIXTURE, analysis_level=2, no_venv=True, cache_dir=tmp_path / "app_mode_l2",
+    )).analyze().application
+    uses = {(_id_suffix(e.src), _id_suffix(e.dst), tuple(e.prov)) for e in app.config_uses}
+    assert ("get_app_mode()@46:11", "APP_MODE", ("literal",)) in uses
+
+
+def test_config_keys_deployment_env(tmp_path):
+    """Verify Dockerfile ENV/ARG and compose environment-map config keys,
+    and their dual-mint into namespace "env" alongside the plain namespace
+    "yaml" dotted path (#165)."""
+    app = _app(tmp_path, "deployment_env_test")
+
+    df_keys = {(k.key, k.namespace, k.value) for k in app.artifacts["Dockerfile"].config_keys}
+    assert df_keys == {
+        ("APP_MODE", "env", "production"),
+        ("BUILD_REV", "dockerfile", None),
+    }
+
+    compose_keys = {(k.key, k.namespace, k.value) for k in app.artifacts["docker-compose.yml"].config_keys}
+    assert compose_keys == {
+        ("services.web.build", "yaml", "."),
+        ("services.web.environment.COMPOSE_ONLY_KEY", "yaml", "x"),
+        ("COMPOSE_ONLY_KEY", "env", "x"),  # dual-mint alongside the dotted yaml key
+    }
+    by = {k.key: k for k in app.artifacts["docker-compose.yml"].config_keys}
+    assert by["COMPOSE_ONLY_KEY"].id != by["services.web.environment.COMPOSE_ONLY_KEY"].id
 
 
 def test_config_uses_tier_visibility(tmp_path):

--- a/test/test_config_key_extraction.py
+++ b/test/test_config_key_extraction.py
@@ -242,6 +242,22 @@ def test_dockerfile_env_legacy_space_form():
     assert _by_key(keys)["MY_NAME"].value == "John Doe"
 
 
+def test_dockerfile_env_legacy_space_form_keeps_quotes_verbatim():
+    # Real Docker does NO quote processing in the legacy form (moby's
+    # parseNameVal) -- unlike the key=value form, quotes stay in the value.
+    art = _artifact("Dockerfile", "dockerfile")
+    keys, ok = extract_config_keys(art, 'ENV MY_NAME "John Doe"\n', True)
+    assert ok is True
+    assert _by_key(keys)["MY_NAME"].value == '"John Doe"'
+
+
+def test_dockerfile_env_legacy_space_form_tab_separated():
+    art = _artifact("Dockerfile", "dockerfile")
+    keys, ok = extract_config_keys(art, "ENV MY_NAME\tJohn Doe\n", True)
+    assert ok is True
+    assert _by_key(keys)["MY_NAME"].value == "John Doe"
+
+
 def test_dockerfile_env_quoted_values_in_multi_key_form():
     art = _artifact("Dockerfile", "dockerfile")
     keys, ok = extract_config_keys(art, 'ENV GREETING="hello world" OTHER=2\n', True)
@@ -258,6 +274,29 @@ def test_dockerfile_env_backslash_continuation():
     assert ok is True
     by = _by_key(keys)
     assert by["A"].value == "1" and by["B"].value == "2" and by["C"].value == "3"
+
+
+def test_dockerfile_env_docker_docs_example_escaped_spaces_and_continuation():
+    # Docker's own ENV docs example: a quoted value, a backslash-escaped-
+    # space value, and a third key on a continuation line -- all three exact.
+    text = (
+        'ENV MY_NAME="John Doe" MY_DOG=Rex\\ The\\ Dog \\\n'
+        '    MY_CAT=fluffy\n'
+    )
+    art = _artifact("Dockerfile", "dockerfile")
+    keys, ok = extract_config_keys(art, text, True)
+    assert ok is True
+    by = _by_key(keys)
+    assert by["MY_NAME"].value == "John Doe"
+    assert by["MY_DOG"].value == "Rex The Dog"
+    assert by["MY_CAT"].value == "fluffy"
+
+
+def test_dockerfile_env_double_backslash_collapses_to_one():
+    art = _artifact("Dockerfile", "dockerfile")
+    keys, ok = extract_config_keys(art, "ENV PATTERN=a\\\\b\n", True)
+    assert ok is True
+    assert _by_key(keys)["PATTERN"].value == "a\\b"
 
 
 def test_dockerfile_arg_with_and_without_default():
@@ -402,6 +441,30 @@ def test_env_recognition_scoped_to_yaml_only_not_json_or_toml():
     assert ok is True
     assert {k.key for k in keys} == {"services.web.environment.APP_MODE"}
     assert all(k.namespace == "json" for k in keys)
+
+
+def test_yaml_top_level_key_and_env_dual_mint_same_name_no_id_collision():
+    # Reviewer-reported: a top-level yaml key sharing a name with a
+    # compose/k8s-recognized env var, in the SAME file, must not collide on
+    # id -- the "differs by construction" claim only holds for the RECOGNIZED
+    # shapes' own dotted paths, not for an unrelated top-level leaf.
+    text = textwrap.dedent("""\
+        COMPOSE_ONLY_KEY: top
+        services:
+          web:
+            environment:
+              COMPOSE_ONLY_KEY: nested
+        """)
+    art = _artifact("docker-compose.yml", "yaml")
+    keys, ok = extract_config_keys(art, text, True)
+    assert ok is True
+    matches = [k for k in keys if k.key == "COMPOSE_ONLY_KEY"]
+    assert len(matches) == 2
+    assert len({k.id for k in matches}) == 2
+    assert {k.namespace for k in matches} == {"yaml", "env"}
+    by_ns = {k.namespace: k for k in matches}
+    assert by_ns["yaml"].value == "top"
+    assert by_ns["env"].value == "nested"
 
 
 def test_compose_k8s_env_recognition_is_deterministic_and_sorted():

--- a/test/test_config_key_extraction.py
+++ b/test/test_config_key_extraction.py
@@ -218,6 +218,212 @@ def test_ini_default_and_section_both_emit_duplicated_key():
     assert by["server.host"].value == "0.0.0.0"
 
 
+# --- dockerfile: ENV/ARG forms, continuations, quoting (#165) --------------
+
+def test_dockerfile_env_single_and_multi_key():
+    text = textwrap.dedent("""\
+        FROM python:3.12-slim
+        ENV APP_MODE=production
+        ENV A=1 B=2
+        """)
+    art = _artifact("Dockerfile", "dockerfile")
+    keys, ok = extract_config_keys(art, text, True)
+    assert ok is True
+    by = _by_key(keys)
+    assert by["APP_MODE"].value == "production" and by["APP_MODE"].namespace == "env"
+    assert by["A"].value == "1" and by["B"].value == "2"
+    assert all(k.namespace == "env" for k in (by["APP_MODE"], by["A"], by["B"]))
+
+
+def test_dockerfile_env_legacy_space_form():
+    art = _artifact("Dockerfile", "dockerfile")
+    keys, ok = extract_config_keys(art, "ENV MY_NAME John Doe\n", True)
+    assert ok is True
+    assert _by_key(keys)["MY_NAME"].value == "John Doe"
+
+
+def test_dockerfile_env_quoted_values_in_multi_key_form():
+    art = _artifact("Dockerfile", "dockerfile")
+    keys, ok = extract_config_keys(art, 'ENV GREETING="hello world" OTHER=2\n', True)
+    assert ok is True
+    by = _by_key(keys)
+    assert by["GREETING"].value == "hello world"
+    assert by["OTHER"].value == "2"
+
+
+def test_dockerfile_env_backslash_continuation():
+    text = "ENV A=1 \\\n    B=2 \\\n    C=3\n"
+    art = _artifact("Dockerfile", "dockerfile")
+    keys, ok = extract_config_keys(art, text, True)
+    assert ok is True
+    by = _by_key(keys)
+    assert by["A"].value == "1" and by["B"].value == "2" and by["C"].value == "3"
+
+
+def test_dockerfile_arg_with_and_without_default():
+    text = "ARG BUILD_REV\nARG VERSION=1.0\n"
+    art = _artifact("Dockerfile", "dockerfile")
+    keys, ok = extract_config_keys(art, text, True)
+    assert ok is True
+    by = _by_key(keys)
+    assert by["BUILD_REV"].value is None and by["BUILD_REV"].namespace == "dockerfile"
+    assert by["VERSION"].value == "1.0" and by["VERSION"].namespace == "dockerfile"
+
+
+def test_dockerfile_arg_and_env_same_name_mint_distinct_ids():
+    # ARG-then-ENV-promotion is a common idiom (`ARG V=1` / `ENV V=$V`) --
+    # both namespaces key on the bare name, so this is the one shape where a
+    # naive id would collide; the "dockerfile" namespace disambiguates.
+    text = "ARG APP_VERSION=1.0\nENV APP_VERSION=$APP_VERSION\n"
+    art = _artifact("Dockerfile", "dockerfile")
+    keys, ok = extract_config_keys(art, text, True)
+    assert ok is True
+    matches = [k for k in keys if k.key == "APP_VERSION"]
+    assert len(matches) == 2
+    assert len({k.id for k in matches}) == 2
+    assert {k.namespace for k in matches} == {"env", "dockerfile"}
+    env_key = next(k for k in matches if k.namespace == "env")
+    assert env_key.value == "$APP_VERSION" and env_key.references == ["$APP_VERSION"]
+
+
+def test_dockerfile_comments_blank_and_other_directives_skipped():
+    text = "# a comment\n\nRUN pip install -e .\nENV OK=1\n"
+    art = _artifact("Dockerfile", "dockerfile")
+    keys, ok = extract_config_keys(art, text, True)
+    assert ok is True
+    assert [k.key for k in keys] == ["OK"]
+
+
+def test_dockerfile_directives_are_case_insensitive():
+    art = _artifact("Dockerfile", "dockerfile")
+    keys, ok = extract_config_keys(art, "env foo=bar\narg baz=qux\n", True)
+    assert ok is True
+    by = _by_key(keys)
+    assert by["foo"].value == "bar" and by["foo"].namespace == "env"
+    assert by["baz"].value == "qux" and by["baz"].namespace == "dockerfile"
+
+
+def test_dockerfile_with_no_env_or_arg_yields_empty():
+    art = _artifact("Dockerfile", "dockerfile")
+    keys, ok = extract_config_keys(art, "FROM python:3.12-slim\n", True)
+    assert keys == [] and ok is True
+
+
+def test_dockerfile_is_config_eligible():
+    assert is_config_eligible(_artifact("Dockerfile", "dockerfile")) is True
+
+
+# --- compose/k8s env recognition: dual-minted "env" namespace keys (#165) --
+
+def test_compose_environment_map_dual_mints_env_namespace():
+    text = textwrap.dedent("""\
+        services:
+          web:
+            build: .
+            environment:
+              APP_MODE: production
+        """)
+    art = _artifact("docker-compose.yml", "yaml")
+    keys, ok = extract_config_keys(art, text, True)
+    assert ok is True
+    by = _by_key(keys)
+    dotted, bare = by["services.web.environment.APP_MODE"], by["APP_MODE"]
+    assert dotted.namespace == "yaml" and dotted.value == "production"
+    assert bare.namespace == "env" and bare.value == "production"
+    assert dotted.id != bare.id  # dual-mint: distinct ids by construction
+
+
+def test_compose_environment_list_dual_mints_env_namespace():
+    text = textwrap.dedent("""\
+        services:
+          web:
+            environment:
+              - APP_MODE=production
+              - BARE_KEY
+        """)
+    art = _artifact("docker-compose.yml", "yaml")
+    keys, ok = extract_config_keys(art, text, True)
+    assert ok is True
+    by = _by_key(keys)
+    assert by["APP_MODE"].namespace == "env" and by["APP_MODE"].value == "production"
+    # a bare list entry ("no value here, inherit from the environment") has
+    # no leaf "=value" to stringify -- same "" a null stringifies to
+    # elsewhere in this module (no dockerfile-ARG-style None distinction was
+    # asked for here).
+    assert by["BARE_KEY"].namespace == "env" and by["BARE_KEY"].value == ""
+    # the plain yaml flatten still sees the list form under its own path.
+    assert by["services.web.environment.0"].namespace == "yaml"
+    assert by["services.web.environment.0"].value == "APP_MODE=production"
+
+
+def test_k8s_env_list_dual_mints_env_namespace_at_any_depth():
+    text = textwrap.dedent("""\
+        spec:
+          template:
+            spec:
+              containers:
+                - name: app
+                  env:
+                    - name: DATABASE_URL
+                      value: postgresql://x
+        """)
+    art = _artifact("k8s/deployment.yml", "yaml")
+    keys, ok = extract_config_keys(art, text, True)
+    assert ok is True
+    by = _by_key(keys)
+    assert by["DATABASE_URL"].namespace == "env"
+    assert by["DATABASE_URL"].value == "postgresql://x"
+    # still dual-minted under its own full dotted path too.
+    assert by["spec.template.spec.containers.0.env.0.name"].namespace == "yaml"
+
+
+def test_k8s_env_list_missing_value_sibling():
+    # a `valueFrom`-style entry (no literal "value:") -- missing sibling,
+    # same "" a null stringifies to elsewhere in this module.
+    text = textwrap.dedent("""\
+        containers:
+          - env:
+              - name: SECRET_REF
+        """)
+    art = _artifact("k8s/pod.yml", "yaml")
+    keys, ok = extract_config_keys(art, text, True)
+    assert ok is True
+    assert _by_key(keys)["SECRET_REF"].namespace == "env"
+    assert _by_key(keys)["SECRET_REF"].value == ""
+
+
+def test_env_recognition_scoped_to_yaml_only_not_json_or_toml():
+    # compose/k8s files are always yaml in this ecosystem -- the recognition
+    # pass is scoped to namespace=="yaml"; the identical shape in json is
+    # NOT dual-minted.
+    text = '{"services": {"web": {"environment": {"APP_MODE": "x"}}}}'
+    art = _artifact("compose.json", "json")
+    keys, ok = extract_config_keys(art, text, True)
+    assert ok is True
+    assert {k.key for k in keys} == {"services.web.environment.APP_MODE"}
+    assert all(k.namespace == "json" for k in keys)
+
+
+def test_compose_k8s_env_recognition_is_deterministic_and_sorted():
+    text = textwrap.dedent("""\
+        services:
+          web:
+            environment:
+              APP_MODE: production
+              OTHER: x
+          db:
+            environment:
+              - DB_KEY=1
+        """)
+    art = _artifact("docker-compose.yml", "yaml")
+    keys1, ok1 = extract_config_keys(art, text, True)
+    keys2, ok2 = extract_config_keys(art, text, True)
+    assert ok1 is True and ok2 is True
+    snap = lambda ks: [(k.id, k.key, k.namespace, k.value) for k in ks]
+    assert snap(keys1) == snap(keys2)
+    assert [k.key for k in keys1] == sorted(k.key for k in keys1)
+
+
 # --- references: all three syntaxes, order of appearance, dedupe -----------
 
 def test_references_all_three_syntaxes_order_and_dedupe():
@@ -267,8 +473,10 @@ def test_literal_dotted_key_collides_with_nesting_last_wins():
 # --- dispatch: unsupported format -> ([], True) -----------------------------
 
 def test_unsupported_format_returns_empty_ok():
-    art = _artifact("Dockerfile", "dockerfile")
-    keys, ok = extract_config_keys(art, "FROM python:3.12\n", True)
+    # "dockerfile" is namespace-eligible as of #165 (see the dedicated
+    # dockerfile section above) -- use a genuinely unsupported format here.
+    art = _artifact("requirements.txt", "requirements")
+    keys, ok = extract_config_keys(art, "requests==2.32.3\n", True)
     assert keys == [] and ok is True
 
 
@@ -303,7 +511,9 @@ def test_is_config_eligible_by_namespace_bearing_format():
 
 
 def test_is_config_eligible_false_for_other_formats():
-    for fmt in ("text", "dockerfile", "requirements"):
+    # "dockerfile" is namespace-eligible as of #165 -- see
+    # test_dockerfile_is_config_eligible above.
+    for fmt in ("text", "requirements"):
         assert is_config_eligible(_artifact("misc", fmt)) is False
 
 


### PR DESCRIPTION
Closes #165.

Config-key extraction now reads where deployments define environment variables:

- **Dockerfile**: `ENV` keys mint namespace `env` (bindable by the environ detectors — controller refinement over the issue text, which proposed a `dockerfile` namespace for both; the DoD requires binding); `ARG` keys mint namespace `dockerfile` (build-time, structurally unreachable by every detector rule). Parser handles multi-key, legacy space form (verbatim, moby-faithful), quoted values, backslash escapes (validated against Docker's own docs example), continuations.
- **compose/k8s**: `services.*.environment` maps/lists and k8s `env: [{name,value}]` lists additionally mint `env`-namespace keys beside their dotted yaml paths (dual-mint intended; ids remapped to avoid same-file collisions).
- Detector table unchanged — resolution picks the new keys up via the existing `env` preference.

e2e proves the first real deployment edge: fixture Dockerfile `ENV APP_MODE=production` + `os.getenv("APP_MODE")` → `PY_USES_CONFIG` at `-a 2`, prov `["literal"]`.

Review: one round (dual-mint id collision, backslash-escape loss — both reviewer-reproduced incl. against moby/buildkit semantics — and legacy-form fidelity), re-review clean. Suite 469 passed / 6 skipped twice; targeted 96/96 post-fix.