### PR TITLE
fix(neo4j)!: scope and gate every Bolt delete; an artifact's source is the whole file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING:** the artifact-text byte cap, its `--artifact-text-max-bytes`
+  flag, and the `PyArtifact.text_truncated` field (also the Neo4j `:Artifact`
+  property). An artifact's `source` is now the whole file, or `""` because it
+  is binary or `--no-artifact-text` was passed -- never a prefix. A truncated
+  `source` read exactly like a complete small file, and the flag meant to
+  distinguish them conflated "whole file" with "capture off"; measured on
+  microsoft/vscode the cap fired on 32 of 4,953 artifacts (0.6%). Matches
+  codeanalyzer-typescript, which removed both in its #117. `--no-artifact-text`
+  is unchanged. python's `dependency-manifest` exemption from the cap is gone
+  with the cap -- every decodable file is captured in full (#172).
+
 ### Fixed
 
 - Neo4j incremental push no longer deletes a sibling analyzer's nodes. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Neo4j incremental push no longer deletes a sibling analyzer's nodes. The
+  per-module purge matched `MATCH (x {_module: $m})` with no label, and
+  `_module` is a shared convention -- `codeanalyzer-java` and
+  `codeanalyzer-typescript` set it on their nodes too -- so where a file key
+  collided, a python push silently detach-deleted their graph. Both statements
+  are now anchored on the python-owned labels, derived from the schema catalog
+  (`MODULE_OWNED_LABELS`) so a new module-scoped label is covered
+  automatically (#171).
+
+### Changed
+
+- A Neo4j Bolt push no longer deletes anything by default. The per-module purge
+  and the full-run orphan prune are the only destructive steps, and both now run
+  under `--eager` only; a default `--lazy` push is purely additive. The cost of
+  the default is staleness -- a declaration or call edge the source no longer has
+  survives until an `--eager` push reconciles it -- and the gain is that an
+  incremental push into a shared database cannot destroy anything (#171).
+
+### Added
+
+- An `_module` index per module-owned Neo4j label. The per-module purge ran as
+  an unindexed scan once per changed module -- quadratic on a full push (#171).
+
 ## [1.3.0] - 2026-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -160,162 +160,132 @@ $ canpy --help
  Static Analysis on Python source code using Jedi and Tree sitter.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
-│ --version                                                                 Show the canpy version │
-│                                                                           and exit.              │
-│ --input                  -i                        <path>                 Path to the project    │
-│                                                                           root directory (not    │
-│                                                                           required for --emit    │
-│                                                                           schema).               │
-│ --output                 -o                        <path>                 Output directory for   │
-│                                                                           artifacts.             │
-│ --emit                                             <json|neo4j|schema>    Output target: json    │
-│                                                                           (analysis.json,        │
-│                                                                           default) | neo4j       │
-│                                                                           (graph.cypher or live  │
-│                                                                           Bolt push) | schema    │
-│                                                                           (the Neo4j schema.json │
-│                                                                           contract).             │
-│                                                                           [default: json]        │
-│ --app-name                                         <str>                  Logical application    │
-│                                                                           name for the graph     │
-│                                                                           :PyApplication anchor  │
-│                                                                           (default: input dir    │
-│                                                                           name).                 │
-│ --neo4j-uri                                        <str>                  Push the graph to a    │
-│                                                                           live Neo4j over Bolt   │
-│                                                                           (incremental); omit to │
-│                                                                           write graph.cypher.    │
-│                                                                           [env var: NEO4J_URI]   │
-│ --neo4j-user                                       <str>                  Neo4j username.        │
-│                                                                           [env var:              │
-│                                                                           NEO4J_USERNAME]        │
-│                                                                           [default: neo4j]       │
-│ --neo4j-password                                   <str>                  Neo4j password. Prefer │
-│                                                                           the env var over the   │
-│                                                                           flag (the flag is      │
-│                                                                           visible in shell       │
-│                                                                           history / process      │
-│                                                                           list).                 │
-│                                                                           [env var:              │
-│                                                                           NEO4J_PASSWORD]        │
-│                                                                           [default: neo4j]       │
-│ --neo4j-database                                   <str>                  Neo4j database name    │
-│                                                                           (default: server       │
-│                                                                           default).              │
-│                                                                           [env var:              │
-│                                                                           NEO4J_DATABASE]        │
-│ --analysis-level         -a                        <int range> [1<=x<=4]  Analysis depth:        │
-│                                                                           1=symbol table+Jedi    │
-│                                                                           call graph,            │
-│                                                                           2=+defuse-linker call  │
-│                                                                           graph, 3=+native       │
-│                                                                           intraprocedural        │
-│                                                                           dataflow (CFG/PDG),    │
-│                                                                           4=+interprocedural SDG │
-│                                                                           (param/summary edges,  │
-│                                                                           alias-aware DDG).      │
-│                                                                           [default: (1)]         │
-│ --graphs                                           <str>                  Level 3+ only:         │
-│                                                                           comma-separated        │
-│                                                                           program-graph sections │
-│                                                                           to emit (cfg, dfg,     │
-│                                                                           pdg, sdg). Default:    │
-│                                                                           cfg,dfg,pdg. `dfg`     │
-│                                                                           emits the PDG's data   │
-│                                                                           edges only; `sdg`      │
-│                                                                           requires -a 4.         │
-│                                                                           Incompatible with      │
-│                                                                           --emit neo4j (always   │
-│                                                                           full-depth).           │
-│                                                                           [default:              │
-│                                                                           (cfg,dfg,pdg)]         │
-│ --graph-field-depth                                <int range> [x>=1]     Level 3 only: k-limit  │
-│                                                                           on access-path depth   │
-│                                                                           (x.f.g.h with k=3      │
-│                                                                           becomes x.f.g.*).      │
-│                                                                           Mandatory bound — it   │
-│                                                                           is what guarantees the │
-│                                                                           interprocedural        │
-│                                                                           fixpoint terminates.   │
-│                                                                           [default: 3]           │
-│ --ray                        --no-ray                                     Enable Ray for         │
-│                                                                           distributed analysis.  │
-│                                                                           [default: no-ray]      │
-│ --eager                      --lazy                                       Enable eager or lazy   │
-│                                                                           analysis. Defaults to  │
-│                                                                           lazy. Also gates every │
-│                                                                           destructive step of a  │
-│                                                                           '--emit neo4j' Bolt    │
-│                                                                           push: a lazy push only │
-│                                                                           adds and updates, an   │
-│                                                                           eager one also removes │
-│                                                                           declarations and edges │
-│                                                                           the source no longer   │
-│                                                                           has.                   │
-│                                                                           [default: lazy]        │
-│ --skip-tests                 --include-tests                              Skip test files in     │
-│                                                                           analysis.              │
-│                                                                           [default: skip-tests]  │
-│ --no-venv                    --venv                                       Skip virtualenv        │
-│                                                                           creation and           │
-│                                                                           dependency             │
-│                                                                           installation; resolve  │
-│                                                                           imports against the    │
-│                                                                           ambient Python         │
-│                                                                           environment instead.   │
-│                                                                           [default: venv]        │
-│ --resolve-installed                                                       Additionally bind      │
-│                                                                           imports via the        │
-│                                                                           project venv's         │
-│                                                                           installed metadata     │
-│                                                                           (*.dist-info); output  │
-│                                                                           becomes                │
-│                                                                           machine-dependent      │
-│                                                                           (prov:                 │
-│                                                                           installed-metadata).   │
-│ --file-name                                        <path>                 Analyze only the       │
-│                                                                           specified file         │
-│                                                                           (relative to input     │
-│                                                                           directory).            │
-│ --cache-dir              -c                        <path>                 Directory to store     │
-│                                                                           analysis cache.        │
-│                                                                           Defaults to            │
-│                                                                           '.codeanalyzer' in the │
-│                                                                           input directory.       │
-│ --clear-cache                --keep-cache                                 Clear cache after      │
-│                                                                           analysis. By default,  │
-│                                                                           cache is retained.     │
-│                                                                           [default: keep-cache]  │
-│                          -v                        <int>                  Increase verbosity:    │
-│                                                                           -v, -vv, -vvv          │
-│                                                                           [default: 0]           │
-│ --entrypoint-rules                                 <path>                 Extra entrypoint rules │
-│                                                                           file (YAML).           │
-│                                                                           Repeatable; merges     │
-│                                                                           with the shipped       │
-│                                                                           rules. A malformed     │
-│                                                                           file is an error.      │
-│ --artifact-text              --no-artifact-text                           Capture verbatim       │
-│                                                                           `source` text on       │
-│                                                                           discovered artifacts.  │
-│                                                                           --no-artifact-text     │
-│                                                                           empties `source`       │
-│                                                                           everywhere (inventory  │
-│                                                                           unchanged).            │
-│                                                                           [default:              │
-│                                                                           artifact-text]         │
-│ --artifact-text-max-by…                            <int range> [x>=1]     Per-file byte cap on   │
-│                                                                           captured artifact      │
-│                                                                           `source`; a decodable  │
-│                                                                           file over the cap is   │
-│                                                                           truncated              │
-│                                                                           (text_truncated=True). │
-│                                                                           sha256/size_bytes      │
-│                                                                           always reflect the     │
-│                                                                           full file.             │
-│                                                                           [default: 262144]      │
-│ --help                                                                    Show this message and  │
-│                                                                           exit.                  │
+│ --version                                                             Show the canpy version and │
+│                                                                       exit.                      │
+│ --input              -i                        <path>                 Path to the project root   │
+│                                                                       directory (not required    │
+│                                                                       for --emit schema).        │
+│ --output             -o                        <path>                 Output directory for       │
+│                                                                       artifacts.                 │
+│ --emit                                         <json|neo4j|schema>    Output target: json        │
+│                                                                       (analysis.json, default) | │
+│                                                                       neo4j (graph.cypher or     │
+│                                                                       live Bolt push) | schema   │
+│                                                                       (the Neo4j schema.json     │
+│                                                                       contract).                 │
+│                                                                       [default: json]            │
+│ --app-name                                     <str>                  Logical application name   │
+│                                                                       for the graph              │
+│                                                                       :PyApplication anchor      │
+│                                                                       (default: input dir name). │
+│ --neo4j-uri                                    <str>                  Push the graph to a live   │
+│                                                                       Neo4j over Bolt            │
+│                                                                       (incremental); omit to     │
+│                                                                       write graph.cypher.        │
+│                                                                       [env var: NEO4J_URI]       │
+│ --neo4j-user                                   <str>                  Neo4j username.            │
+│                                                                       [env var: NEO4J_USERNAME]  │
+│                                                                       [default: neo4j]           │
+│ --neo4j-password                               <str>                  Neo4j password. Prefer the │
+│                                                                       env var over the flag (the │
+│                                                                       flag is visible in shell   │
+│                                                                       history / process list).   │
+│                                                                       [env var: NEO4J_PASSWORD]  │
+│                                                                       [default: neo4j]           │
+│ --neo4j-database                               <str>                  Neo4j database name        │
+│                                                                       (default: server default). │
+│                                                                       [env var: NEO4J_DATABASE]  │
+│ --analysis-level     -a                        <int range> [1<=x<=4]  Analysis depth: 1=symbol   │
+│                                                                       table+Jedi call graph,     │
+│                                                                       2=+defuse-linker call      │
+│                                                                       graph, 3=+native           │
+│                                                                       intraprocedural dataflow   │
+│                                                                       (CFG/PDG),                 │
+│                                                                       4=+interprocedural SDG     │
+│                                                                       (param/summary edges,      │
+│                                                                       alias-aware DDG).          │
+│                                                                       [default: (1)]             │
+│ --graphs                                       <str>                  Level 3+ only:             │
+│                                                                       comma-separated            │
+│                                                                       program-graph sections to  │
+│                                                                       emit (cfg, dfg, pdg, sdg). │
+│                                                                       Default: cfg,dfg,pdg.      │
+│                                                                       `dfg` emits the PDG's data │
+│                                                                       edges only; `sdg` requires │
+│                                                                       -a 4. Incompatible with    │
+│                                                                       --emit neo4j (always       │
+│                                                                       full-depth).               │
+│                                                                       [default: (cfg,dfg,pdg)]   │
+│ --graph-field-depth                            <int range> [x>=1]     Level 3 only: k-limit on   │
+│                                                                       access-path depth (x.f.g.h │
+│                                                                       with k=3 becomes x.f.g.*). │
+│                                                                       Mandatory bound — it is    │
+│                                                                       what guarantees the        │
+│                                                                       interprocedural fixpoint   │
+│                                                                       terminates.                │
+│                                                                       [default: 3]               │
+│ --ray                    --no-ray                                     Enable Ray for distributed │
+│                                                                       analysis.                  │
+│                                                                       [default: no-ray]          │
+│ --eager                  --lazy                                       Enable eager or lazy       │
+│                                                                       analysis. Defaults to      │
+│                                                                       lazy. Also gates every     │
+│                                                                       destructive step of a      │
+│                                                                       '--emit neo4j' Bolt push:  │
+│                                                                       a lazy push only adds and  │
+│                                                                       updates, an eager one also │
+│                                                                       removes declarations and   │
+│                                                                       edges the source no longer │
+│                                                                       has.                       │
+│                                                                       [default: lazy]            │
+│ --skip-tests             --include-tests                              Skip test files in         │
+│                                                                       analysis.                  │
+│                                                                       [default: skip-tests]      │
+│ --no-venv                --venv                                       Skip virtualenv creation   │
+│                                                                       and dependency             │
+│                                                                       installation; resolve      │
+│                                                                       imports against the        │
+│                                                                       ambient Python environment │
+│                                                                       instead.                   │
+│                                                                       [default: venv]            │
+│ --resolve-installed                                                   Additionally bind imports  │
+│                                                                       via the project venv's     │
+│                                                                       installed metadata         │
+│                                                                       (*.dist-info); output      │
+│                                                                       becomes machine-dependent  │
+│                                                                       (prov:                     │
+│                                                                       installed-metadata).       │
+│ --file-name                                    <path>                 Analyze only the specified │
+│                                                                       file (relative to input    │
+│                                                                       directory).                │
+│ --cache-dir          -c                        <path>                 Directory to store         │
+│                                                                       analysis cache. Defaults   │
+│                                                                       to '.codeanalyzer' in the  │
+│                                                                       input directory.           │
+│ --clear-cache            --keep-cache                                 Clear cache after          │
+│                                                                       analysis. By default,      │
+│                                                                       cache is retained.         │
+│                                                                       [default: keep-cache]      │
+│                      -v                        <int>                  Increase verbosity: -v,    │
+│                                                                       -vv, -vvv                  │
+│                                                                       [default: 0]               │
+│ --entrypoint-rules                             <path>                 Extra entrypoint rules     │
+│                                                                       file (YAML). Repeatable;   │
+│                                                                       merges with the shipped    │
+│                                                                       rules. A malformed file is │
+│                                                                       an error.                  │
+│ --artifact-text          --no-artifact-text                           Capture verbatim `source`  │
+│                                                                       text on discovered         │
+│                                                                       artifacts. `source` is the │
+│                                                                       whole file;                │
+│                                                                       --no-artifact-text empties │
+│                                                                       it everywhere (inventory   │
+│                                                                       unchanged).                │
+│                                                                       sha256/size_bytes always   │
+│                                                                       reflect the full file.     │
+│                                                                       [default: artifact-text]   │
+│ --help                                                                Show this message and      │
+│                                                                       exit.                      │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ needs.
   **interprocedural SDG** (synthetic parameter vertices, `param_in`/`param_out`/`summary`,
   alias-aware DDG) at level 4 — all built in-process from the stdlib `ast`.
 - **Neo4j output** — project the analysis into a labeled property graph: a self-contained
-  `graph.cypher` snapshot, or an **incremental** push to a live database over Bolt.
+  `graph.cypher` snapshot, or an **incremental** push to a live database over Bolt. A push is
+  **additive by default** and never deletes: `--eager` is what permits it to remove declarations
+  and edges the source no longer has.
 - **Versioned schema** — a machine-readable, version-stamped Neo4j schema contract (`--emit schema`),
   checked in as `schema.neo4j.json` (`2.0.0`) and shipped with every release.
 - **Incremental cache** — per-file results are cached under `.codeanalyzer`; `--lazy` (default)
@@ -157,201 +159,164 @@ $ canpy --help
 
  Static Analysis on Python source code using Jedi and Tree sitter.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --version                                                   Show the canpy   │
-│                                                             version and      │
-│                                                             exit.            │
-│ --input            -i                     <path>            Path to the      │
-│                                                             project root     │
-│                                                             directory (not   │
-│                                                             required for     │
-│                                                             --emit schema).  │
-│ --output           -o                     <path>            Output directory │
-│                                                             for artifacts.   │
-│ --emit                                    <json|neo4j|sche  Output target:   │
-│                                           ma>               json             │
-│                                                             (analysis.json,  │
-│                                                             default) | neo4j │
-│                                                             (graph.cypher or │
-│                                                             live Bolt push)  │
-│                                                             | schema (the    │
-│                                                             Neo4j            │
-│                                                             schema.json      │
-│                                                             contract).       │
-│                                                             [default: json]  │
-│ --app-name                                <str>             Logical          │
-│                                                             application name │
-│                                                             for the graph    │
-│                                                             :PyApplication   │
-│                                                             anchor (default: │
-│                                                             input dir name). │
-│ --neo4j-uri                               <str>             Push the graph   │
-│                                                             to a live Neo4j  │
-│                                                             over Bolt        │
-│                                                             (incremental);   │
-│                                                             omit to write    │
-│                                                             graph.cypher.    │
-│                                                             [env var:        │
-│                                                             NEO4J_URI]       │
-│ --neo4j-user                              <str>             Neo4j username.  │
-│                                                             [env var:        │
-│                                                             NEO4J_USERNAME]  │
-│                                                             [default: neo4j] │
-│ --neo4j-password                          <str>             Neo4j password.  │
-│                                                             Prefer the env   │
-│                                                             var over the     │
-│                                                             flag (the flag   │
-│                                                             is visible in    │
-│                                                             shell history /  │
-│                                                             process list).   │
-│                                                             [env var:        │
-│                                                             NEO4J_PASSWORD]  │
-│                                                             [default: neo4j] │
-│ --neo4j-database                          <str>             Neo4j database   │
-│                                                             name (default:   │
-│                                                             server default). │
-│                                                             [env var:        │
-│                                                             NEO4J_DATABASE]  │
-│ --analysis-level   -a                     <int range>       Analysis depth:  │
-│                                           [1<=x<=4]         1=symbol         │
-│                                                             table+Jedi call  │
-│                                                             graph,           │
-│                                                             2=+defuse-linker │
-│                                                             call graph,      │
-│                                                             3=+native        │
-│                                                             intraprocedural  │
-│                                                             dataflow         │
-│                                                             (CFG/PDG),       │
-│                                                             4=+interprocedu… │
-│                                                             SDG              │
-│                                                             (param/summary   │
-│                                                             edges,           │
-│                                                             alias-aware      │
-│                                                             DDG).            │
-│                                                             [default: (1)]   │
-│ --graphs                                  <str>             Level 3+ only:   │
-│                                                             comma-separated  │
-│                                                             program-graph    │
-│                                                             sections to emit │
-│                                                             (cfg, dfg, pdg,  │
-│                                                             sdg). Default:   │
-│                                                             cfg,dfg,pdg.     │
-│                                                             `dfg` emits the  │
-│                                                             PDG's data edges │
-│                                                             only; `sdg`      │
-│                                                             requires -a 4.   │
-│                                                             Incompatible     │
-│                                                             with --emit      │
-│                                                             neo4j (always    │
-│                                                             full-depth).     │
-│                                                             [default:        │
-│                                                             (cfg,dfg,pdg)]   │
-│ --graph-field-de…                         <int range>       Level 3 only:    │
-│                                           [x>=1]            k-limit on       │
-│                                                             access-path      │
-│                                                             depth (x.f.g.h   │
-│                                                             with k=3 becomes │
-│                                                             x.f.g.*).        │
-│                                                             Mandatory bound  │
-│                                                             — it is what     │
-│                                                             guarantees the   │
-│                                                             interprocedural  │
-│                                                             fixpoint         │
-│                                                             terminates.      │
-│                                                             [default: 3]     │
-│ --ray                  --no-ray                             Enable Ray for   │
-│                                                             distributed      │
-│                                                             analysis.        │
-│                                                             [default:        │
-│                                                             no-ray]          │
-│ --eager                --lazy                               Enable eager or  │
-│                                                             lazy analysis.   │
-│                                                             Defaults to      │
-│                                                             lazy.            │
-│                                                             [default: lazy]  │
-│ --skip-tests           --include-tests                      Skip test files  │
-│                                                             in analysis.     │
-│                                                             [default:        │
-│                                                             skip-tests]      │
-│ --no-venv              --venv                               Skip virtualenv  │
-│                                                             creation and     │
-│                                                             dependency       │
-│                                                             installation;    │
-│                                                             resolve imports  │
-│                                                             against the      │
-│                                                             ambient Python   │
-│                                                             environment      │
-│                                                             instead.         │
-│                                                             [default: venv]  │
-│ --resolve-instal…                                           Additionally     │
-│                                                             bind imports via │
-│                                                             the project      │
-│                                                             venv's installed │
-│                                                             metadata         │
-│                                                             (*.dist-info);   │
-│                                                             output becomes   │
-│                                                             machine-depende… │
-│                                                             (prov:           │
-│                                                             installed-metad… │
-│ --file-name                               <path>            Analyze only the │
-│                                                             specified file   │
-│                                                             (relative to     │
-│                                                             input            │
-│                                                             directory).      │
-│ --cache-dir        -c                     <path>            Directory to     │
-│                                                             store analysis   │
-│                                                             cache. Defaults  │
-│                                                             to               │
-│                                                             '.codeanalyzer'  │
-│                                                             in the input     │
-│                                                             directory.       │
-│ --clear-cache          --keep-cache                         Clear cache      │
-│                                                             after analysis.  │
-│                                                             By default,      │
-│                                                             cache is         │
-│                                                             retained.        │
-│                                                             [default:        │
-│                                                             keep-cache]      │
-│                    -v                     <int>             Increase         │
-│                                                             verbosity: -v,   │
-│                                                             -vv, -vvv        │
-│                                                             [default: 0]     │
-│ --entrypoint-rul…                         <path>            Extra entrypoint │
-│                                                             rules file       │
-│                                                             (YAML).          │
-│                                                             Repeatable;      │
-│                                                             merges with the  │
-│                                                             shipped rules. A │
-│                                                             malformed file   │
-│                                                             is an error.     │
-│ --artifact-text        --no-artifact-…                      Capture verbatim │
-│                                                             `source` text on │
-│                                                             discovered       │
-│                                                             artifacts.       │
-│                                                             --no-artifact-t… │
-│                                                             empties `source` │
-│                                                             everywhere       │
-│                                                             (inventory       │
-│                                                             unchanged).      │
-│                                                             [default:        │
-│                                                             artifact-text]   │
-│ --artifact-text-…                         <int range>       Per-file byte    │
-│                                           [x>=1]            cap on captured  │
-│                                                             artifact         │
-│                                                             `source`; a      │
-│                                                             decodable file   │
-│                                                             over the cap is  │
-│                                                             truncated        │
-│                                                             (text_truncated… │
-│                                                             sha256/size_byt… │
-│                                                             always reflect   │
-│                                                             the full file.   │
-│                                                             [default:        │
-│                                                             262144]          │
-│ --help                                                      Show this        │
-│                                                             message and      │
-│                                                             exit.            │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --version                                                                 Show the canpy version │
+│                                                                           and exit.              │
+│ --input                  -i                        <path>                 Path to the project    │
+│                                                                           root directory (not    │
+│                                                                           required for --emit    │
+│                                                                           schema).               │
+│ --output                 -o                        <path>                 Output directory for   │
+│                                                                           artifacts.             │
+│ --emit                                             <json|neo4j|schema>    Output target: json    │
+│                                                                           (analysis.json,        │
+│                                                                           default) | neo4j       │
+│                                                                           (graph.cypher or live  │
+│                                                                           Bolt push) | schema    │
+│                                                                           (the Neo4j schema.json │
+│                                                                           contract).             │
+│                                                                           [default: json]        │
+│ --app-name                                         <str>                  Logical application    │
+│                                                                           name for the graph     │
+│                                                                           :PyApplication anchor  │
+│                                                                           (default: input dir    │
+│                                                                           name).                 │
+│ --neo4j-uri                                        <str>                  Push the graph to a    │
+│                                                                           live Neo4j over Bolt   │
+│                                                                           (incremental); omit to │
+│                                                                           write graph.cypher.    │
+│                                                                           [env var: NEO4J_URI]   │
+│ --neo4j-user                                       <str>                  Neo4j username.        │
+│                                                                           [env var:              │
+│                                                                           NEO4J_USERNAME]        │
+│                                                                           [default: neo4j]       │
+│ --neo4j-password                                   <str>                  Neo4j password. Prefer │
+│                                                                           the env var over the   │
+│                                                                           flag (the flag is      │
+│                                                                           visible in shell       │
+│                                                                           history / process      │
+│                                                                           list).                 │
+│                                                                           [env var:              │
+│                                                                           NEO4J_PASSWORD]        │
+│                                                                           [default: neo4j]       │
+│ --neo4j-database                                   <str>                  Neo4j database name    │
+│                                                                           (default: server       │
+│                                                                           default).              │
+│                                                                           [env var:              │
+│                                                                           NEO4J_DATABASE]        │
+│ --analysis-level         -a                        <int range> [1<=x<=4]  Analysis depth:        │
+│                                                                           1=symbol table+Jedi    │
+│                                                                           call graph,            │
+│                                                                           2=+defuse-linker call  │
+│                                                                           graph, 3=+native       │
+│                                                                           intraprocedural        │
+│                                                                           dataflow (CFG/PDG),    │
+│                                                                           4=+interprocedural SDG │
+│                                                                           (param/summary edges,  │
+│                                                                           alias-aware DDG).      │
+│                                                                           [default: (1)]         │
+│ --graphs                                           <str>                  Level 3+ only:         │
+│                                                                           comma-separated        │
+│                                                                           program-graph sections │
+│                                                                           to emit (cfg, dfg,     │
+│                                                                           pdg, sdg). Default:    │
+│                                                                           cfg,dfg,pdg. `dfg`     │
+│                                                                           emits the PDG's data   │
+│                                                                           edges only; `sdg`      │
+│                                                                           requires -a 4.         │
+│                                                                           Incompatible with      │
+│                                                                           --emit neo4j (always   │
+│                                                                           full-depth).           │
+│                                                                           [default:              │
+│                                                                           (cfg,dfg,pdg)]         │
+│ --graph-field-depth                                <int range> [x>=1]     Level 3 only: k-limit  │
+│                                                                           on access-path depth   │
+│                                                                           (x.f.g.h with k=3      │
+│                                                                           becomes x.f.g.*).      │
+│                                                                           Mandatory bound — it   │
+│                                                                           is what guarantees the │
+│                                                                           interprocedural        │
+│                                                                           fixpoint terminates.   │
+│                                                                           [default: 3]           │
+│ --ray                        --no-ray                                     Enable Ray for         │
+│                                                                           distributed analysis.  │
+│                                                                           [default: no-ray]      │
+│ --eager                      --lazy                                       Enable eager or lazy   │
+│                                                                           analysis. Defaults to  │
+│                                                                           lazy. Also gates every │
+│                                                                           destructive step of a  │
+│                                                                           '--emit neo4j' Bolt    │
+│                                                                           push: a lazy push only │
+│                                                                           adds and updates, an   │
+│                                                                           eager one also removes │
+│                                                                           declarations and edges │
+│                                                                           the source no longer   │
+│                                                                           has.                   │
+│                                                                           [default: lazy]        │
+│ --skip-tests                 --include-tests                              Skip test files in     │
+│                                                                           analysis.              │
+│                                                                           [default: skip-tests]  │
+│ --no-venv                    --venv                                       Skip virtualenv        │
+│                                                                           creation and           │
+│                                                                           dependency             │
+│                                                                           installation; resolve  │
+│                                                                           imports against the    │
+│                                                                           ambient Python         │
+│                                                                           environment instead.   │
+│                                                                           [default: venv]        │
+│ --resolve-installed                                                       Additionally bind      │
+│                                                                           imports via the        │
+│                                                                           project venv's         │
+│                                                                           installed metadata     │
+│                                                                           (*.dist-info); output  │
+│                                                                           becomes                │
+│                                                                           machine-dependent      │
+│                                                                           (prov:                 │
+│                                                                           installed-metadata).   │
+│ --file-name                                        <path>                 Analyze only the       │
+│                                                                           specified file         │
+│                                                                           (relative to input     │
+│                                                                           directory).            │
+│ --cache-dir              -c                        <path>                 Directory to store     │
+│                                                                           analysis cache.        │
+│                                                                           Defaults to            │
+│                                                                           '.codeanalyzer' in the │
+│                                                                           input directory.       │
+│ --clear-cache                --keep-cache                                 Clear cache after      │
+│                                                                           analysis. By default,  │
+│                                                                           cache is retained.     │
+│                                                                           [default: keep-cache]  │
+│                          -v                        <int>                  Increase verbosity:    │
+│                                                                           -v, -vv, -vvv          │
+│                                                                           [default: 0]           │
+│ --entrypoint-rules                                 <path>                 Extra entrypoint rules │
+│                                                                           file (YAML).           │
+│                                                                           Repeatable; merges     │
+│                                                                           with the shipped       │
+│                                                                           rules. A malformed     │
+│                                                                           file is an error.      │
+│ --artifact-text              --no-artifact-text                           Capture verbatim       │
+│                                                                           `source` text on       │
+│                                                                           discovered artifacts.  │
+│                                                                           --no-artifact-text     │
+│                                                                           empties `source`       │
+│                                                                           everywhere (inventory  │
+│                                                                           unchanged).            │
+│                                                                           [default:              │
+│                                                                           artifact-text]         │
+│ --artifact-text-max-by…                            <int range> [x>=1]     Per-file byte cap on   │
+│                                                                           captured artifact      │
+│                                                                           `source`; a decodable  │
+│                                                                           file over the cap is   │
+│                                                                           truncated              │
+│                                                                           (text_truncated=True). │
+│                                                                           sha256/size_bytes      │
+│                                                                           always reflect the     │
+│                                                                           full file.             │
+│                                                                           [default: 262144]      │
+│ --help                                                                    Show this message and  │
+│                                                                           exit.                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 <!-- END canpy-help -->

--- a/codeanalyzer/__main__.py
+++ b/codeanalyzer/__main__.py
@@ -242,19 +242,11 @@ def main(
         typer.Option(
             "--artifact-text/--no-artifact-text",
             help="Capture verbatim `source` text on discovered artifacts. "
-            "--no-artifact-text empties `source` everywhere (inventory unchanged).",
+            "`source` is the whole file; --no-artifact-text empties it "
+            "everywhere (inventory unchanged). sha256/size_bytes always "
+            "reflect the full file.",
         ),
     ] = True,
-    artifact_text_max_bytes: Annotated[
-        int,
-        typer.Option(
-            "--artifact-text-max-bytes",
-            help="Per-file byte cap on captured artifact `source`; a decodable "
-            "file over the cap is truncated (text_truncated=True). "
-            "sha256/size_bytes always reflect the full file.",
-            min=1,
-        ),
-    ] = 262144,
 ):
     # Determinism: pin the interpreter hash seed before any analysis (no-op
     # when PYTHONHASHSEED is already set; --version exits before this).
@@ -339,7 +331,6 @@ def main(
         verbosity=verbosity,
         entrypoint_rules=tuple(entrypoint_rules or ()),
         artifact_text=artifact_text,
-        artifact_text_max_bytes=artifact_text_max_bytes,
     )
 
     _set_log_level(options.verbosity)

--- a/codeanalyzer/__main__.py
+++ b/codeanalyzer/__main__.py
@@ -175,7 +175,10 @@ def main(
         bool,
         typer.Option(
             "--eager/--lazy",
-            help="Enable eager or lazy analysis. Defaults to lazy.",
+            help="Enable eager or lazy analysis. Defaults to lazy. Also gates every "
+            "destructive step of a '--emit neo4j' Bolt push: a lazy push only adds and "
+            "updates, an eager one also removes declarations and edges the source no "
+            "longer has.",
         ),
     ] = False,
     skip_tests: Annotated[

--- a/codeanalyzer/artifacts/dependencies.py
+++ b/codeanalyzer/artifacts/dependencies.py
@@ -81,9 +81,9 @@ def _resolve_ref(manifest_path: str, ref: str) -> Optional[str]:
 
 def _full_text(project_dir: Path, path: str, art: PyArtifact) -> str:
     """Manifest/lock extraction must never depend on the stored ``source`` --
-    that's capped by ``text_max_bytes`` and emptied by ``capture_text=False``
-    (both payload-size controls on the JSON/Neo4j payload, not extraction
-    controls). Read the real file fresh instead; fall back to ``art.source``
+    that's emptied by ``capture_text=False`` (a payload-size control on the
+    JSON/Neo4j payload, not an extraction control). Read the real file fresh
+    instead; fall back to ``art.source``
     only if it is gone (e.g. a synthetic artifact in a unit test, or the file
     vanished mid-run).
 

--- a/codeanalyzer/artifacts/discovery.py
+++ b/codeanalyzer/artifacts/discovery.py
@@ -76,27 +76,11 @@ def _classify(rel_posix: str) -> Tuple[str, List[str]] | None:
     return None
 
 
-def _capture_source(
-    raw: bytes, text: str, capture_text: bool, text_max_bytes: int
-) -> Tuple[str, bool]:
-    """Decide ``(source, text_truncated)`` for a decodable file.
-
-    Slices ``raw`` (not ``text``) for the cap, so it is a true byte cap even
-    when it lands inside a multi-byte character -- ``errors="ignore"`` drops
-    the dangling partial char at the cut, so this never raises."""
-    if not capture_text:
-        return "", False
-    if len(raw) <= text_max_bytes:
-        return text, False
-    return raw[:text_max_bytes].decode("utf-8", errors="ignore"), True
-
-
 def discover_artifacts(
     project_dir: Path,
     app_name: str,
     *,
     capture_text: bool = True,
-    text_max_bytes: int = 262144,
 ) -> Dict[str, PyArtifact]:
     """Walk the project and return every file as an artifact, sorted by path.
 
@@ -109,15 +93,11 @@ def discover_artifacts(
     deliberate exception -- it IS rule-matched (a dependency-manifest), so it
     is captured like any other manifest despite the `.py` suffix.
 
-    ``capture_text=False`` empties ``source`` everywhere (inventory otherwise
-    identical); a decodable file over ``text_max_bytes`` gets a truncated
-    ``source`` and ``text_truncated=True`` -- except a ``dependency-manifest``
-    role artifact, which is always captured in full when decodable and
-    ``capture_text`` is on: its source is what ``build_dependency_view``
-    parses, not bulk/incidental content, so the byte cap does not apply to
-    it (``capture_text=False`` still empties it like everything else).
-    ``sha256``/``size_bytes`` always reflect the full file regardless of
-    either knob."""
+    ``source`` is the WHOLE file or nothing -- never a prefix (#172). A
+    decodable file is captured in full; ``capture_text=False`` empties
+    ``source`` everywhere (inventory otherwise identical), and an undecodable
+    file gets ``""`` as ``binary``. ``sha256``/``size_bytes`` always reflect
+    the full file regardless."""
     out: Dict[str, PyArtifact] = {}
     for path in sorted(project_dir.rglob("*")):
         if not path.is_file():
@@ -148,20 +128,14 @@ def discover_artifacts(
             if decodable and "." not in name and text.startswith("#!"):
                 roles = ["script"]
         if decodable:
-            # A dependency-manifest's source IS the extracted meaning (build_
-            # dependency_view parses it) -- the byte cap targets bulk/incidental
-            # assets, never the files extraction depends on, so manifests are
-            # exempt from it. capture_text=False still empties source (handled
-            # inside _capture_source); only the byte CAP is bypassed here.
-            cap = len(raw) if "dependency-manifest" in roles else text_max_bytes
-            source, text_truncated = _capture_source(raw, text, capture_text, cap)
+            source = text if capture_text else ""
         else:
-            fmt, source, text_truncated = "binary", "", False
+            fmt, source = "binary", ""
 
         out[rel_posix] = PyArtifact(
             id=artifact_id(app_name, rel_posix), path=rel_posix, format=fmt,
             roles=list(roles), size_bytes=len(raw),
             sha256=hashlib.sha256(raw).hexdigest(),
-            source=source, text_truncated=text_truncated,
+            source=source,
         )
     return out

--- a/codeanalyzer/core.py
+++ b/codeanalyzer/core.py
@@ -40,9 +40,9 @@ from codeanalyzer.provenance import analyzer_info, repository_info
 def _artifact_full_text(project_dir: Path, path: str, art) -> str:
     """Mirrors ``artifacts.dependencies._full_text`` verbatim (not imported
     -- that name is module-private to ``dependencies.py``): config-key
-    extraction (#152) must never depend on the stored ``source`` -- capped
-    by ``text_max_bytes`` and emptied by ``capture_text=False`` (payload-size
-    controls, not extraction controls). Read the real file fresh instead;
+    extraction (#152) must never depend on the stored ``source`` -- emptied
+    by ``capture_text=False`` (a payload-size control, not an extraction
+    control). Read the real file fresh instead;
     fall back to ``art.source`` only if it's gone (e.g. a synthetic artifact
     in a unit test, or the file vanished mid-run). Keep the two in sync if
     this logic changes."""
@@ -673,7 +673,6 @@ class Codeanalyzer:
         app.artifacts = discover_artifacts(
             self.project_dir, app_name,
             capture_text=self.options.artifact_text,
-            text_max_bytes=self.options.artifact_text_max_bytes,
         )
         app.dependencies, app.unresolved_imports = build_dependency_view(
             app.artifacts,

--- a/codeanalyzer/neo4j/bolt.py
+++ b/codeanalyzer/neo4j/bolt.py
@@ -27,10 +27,23 @@ Algorithm (the module subgraph is the unit of idempotent replacement):
   4. upsert edges owned by changed modules (+ the shared edges).
   5. on a FULL run only, prune modules whose source file vanished.
 
+**A push never deletes by default** (#171). Steps 3 and 5 are the only destructive
+ones and both run on ``eager`` (``--eager``) only; a default ``--lazy`` push is purely
+additive — MERGE-upsert of nodes and edges, nothing removed. The cost of the default is
+staleness: a declaration or a call edge the source no longer has stays in the graph until
+an ``--eager`` push reconciles it. That is the deliberate trade — an incremental push into
+a shared database should not be able to destroy anything, and the destructive rebuild is
+opt-in under the same flag that already forces a clean analysis rebuild.
+
 Nodes are MERGE-upserted, never blindly deleted, so a declaration another
 (unchanged) module still references survives and its incoming edges stay valid.
 ``:PyExternal`` / ``:PyPackage`` / ``:PyDecorator`` are shared (no ``_module``) and are
 MERGE-only.
+
+Every ``_module`` match is anchored on the python-owned labels
+(``schema.MODULE_OWNED_PATTERN``). ``_module`` is a shared convention, not a python-private
+one -- codeanalyzer-java and codeanalyzer-typescript set it on their nodes too -- so an
+unlabelled match reaches a sibling analyzer's graph in a shared database (#171).
 
 The ``neo4j`` driver is imported lazily so it stays an optional dependency and
 off the default (json) output path entirely.
@@ -41,7 +54,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 from codeanalyzer.neo4j.rows import EdgeRow, GraphRows, NodeRow, chunk
-from codeanalyzer.neo4j.schema import CONSTRAINTS, INDEXES
+from codeanalyzer.neo4j.schema import CONSTRAINTS, INDEXES, MODULE_OWNED_PATTERN
 from codeanalyzer.utils import logger
 
 DESCENDANTS = (
@@ -59,7 +72,7 @@ class BoltConfig:
     database: Optional[str] = None
 
 
-def bolt_writer(rows: GraphRows, cfg: BoltConfig, full_run: bool) -> None:
+def bolt_writer(rows: GraphRows, cfg: BoltConfig, full_run: bool, eager: bool = False) -> None:
     try:
         import neo4j  # noqa: WPS433 (lazy, optional dependency)
     except ImportError as exc:  # pragma: no cover - exercised only without the extra
@@ -119,15 +132,26 @@ def bolt_writer(rows: GraphRows, cfg: BoltConfig, full_run: bool) -> None:
         _upsert_nodes(session, neo4j, shared)
 
         # 4. per changed module: purge owned edges + vanished decls, then upsert its nodes.
+        # The purge is the only destructive step in a push, so it runs on --eager only.
         for m in changed:
             nodes = by_module[m]
             keys = [n.value for n in nodes]
+            if not eager:
+                _upsert_nodes(session, neo4j, nodes)
+                continue
             with session() as s:
                 def _purge(tx, module=m, node_keys=keys):
-                    tx.run("MATCH (x {_module: $m})-[r]->() DELETE r", m=module)
+                    # Anchored on python-owned labels: `_module` is also set by the java
+                    # and typescript analyzers, so an unlabelled match would delete a
+                    # sibling's nodes wherever a file key collides (#171).
                     tx.run(
-                        "MATCH (x {_module: $m}) "
-                        "WHERE NOT coalesce(x.signature, x.id, x.file_key) IN $keys "
+                        f"MATCH (x:{MODULE_OWNED_PATTERN}) WHERE x._module = $m "
+                        "MATCH (x)-[r]->() DELETE r",
+                        m=module,
+                    )
+                    tx.run(
+                        f"MATCH (x:{MODULE_OWNED_PATTERN}) WHERE x._module = $m "
+                        "AND NOT coalesce(x.signature, x.id, x.file_key) IN $keys "
                         "DETACH DELETE x",
                         m=module,
                         keys=node_keys,
@@ -147,7 +171,7 @@ def bolt_writer(rows: GraphRows, cfg: BoltConfig, full_run: bool) -> None:
         # 6. orphan prune — only safe on a full run (a targeted run can't tell deleted from untargeted).
         # Scope to THIS application's anchor so a full run for application B never
         # deletes application A's modules from a shared database.
-        if full_run and app_name is not None:
+        if full_run and eager and app_name is not None:
             present = list(by_module.keys())
             with session() as s:
                 res = s.run(
@@ -161,6 +185,11 @@ def bolt_writer(rows: GraphRows, cfg: BoltConfig, full_run: bool) -> None:
                 pruned = res.single()
                 pruned_count = pruned["pruned"] if pruned else 0
                 logger.info(f"neo4j(bolt): pruned {pruned_count} vanished module(s)")
+        elif not eager:
+            logger.info(
+                "neo4j(bolt): additive push (--lazy) — nothing deleted; "
+                "re-run with --eager to reconcile removed declarations and edges"
+            )
         else:
             logger.info(
                 "neo4j(bolt): targeted run — orphan pruning skipped (deleted files not removed)"

--- a/codeanalyzer/neo4j/emit.py
+++ b/codeanalyzer/neo4j/emit.py
@@ -67,9 +67,10 @@ def emit_neo4j(analysis: Analysis, options: AnalysisOptions) -> None:
             password=options.neo4j_password,
             database=options.neo4j_database,
         )
-        # A full run (no single-file restriction) makes orphan pruning safe.
+        # A full run (no single-file restriction) makes orphan pruning safe; --eager
+        # is what permits any deletion at all (#171).
         full_run = options.file_name is None
-        bolt_writer(rows, cfg, full_run)
+        bolt_writer(rows, cfg, full_run, eager=options.rebuild_analysis)
         return
 
     out_dir = options.output if options.output is not None else Path.cwd()

--- a/codeanalyzer/neo4j/project.py
+++ b/codeanalyzer/neo4j/project.py
@@ -309,7 +309,6 @@ def _project_artifacts(b: RowBuilder, app: PyApplication, app_name: str, app_ref
                     "size_bytes": art.size_bytes,
                     "sha256": art.sha256,
                     "source": art.source,
-                    "text_truncated": art.text_truncated,
                     "extraction": art.extraction,
                 }
             ),

--- a/codeanalyzer/neo4j/schema.py
+++ b/codeanalyzer/neo4j/schema.py
@@ -332,10 +332,27 @@ def uniqueness_constraints() -> list[str]:
 
 CONSTRAINTS: List[str] = uniqueness_constraints()
 
+# The labels this analyzer owns per module -- the ones carrying the internal ``_module``
+# provenance property. Derived from NODE_LABELS so a new module-scoped label is covered
+# without a second list to maintain. `_module` is NOT python-private: codeanalyzer-java
+# and codeanalyzer-typescript set the same property on their nodes, so every statement
+# matching on it must be anchored to these labels or it matches a sibling analyzer's graph
+# in a shared database (#171).
+MODULE_OWNED_LABELS: List[str] = [n.label for n in NODE_LABELS if "_module" in n.properties]
+
+# The label disjunction to anchor such a statement with: ``MATCH (x:PyModule|PyClass|...)``.
+MODULE_OWNED_PATTERN: str = "|".join(MODULE_OWNED_LABELS)
+
 INDEXES: List[str] = [
     "CREATE INDEX py_callable_name IF NOT EXISTS FOR (c:PyCallable) ON (c.name)",
     "CREATE INDEX py_class_name IF NOT EXISTS FOR (c:PyClass) ON (c.name)",
     "CREATE FULLTEXT INDEX py_code_fts IF NOT EXISTS FOR (c:PyCallable) ON EACH [c.code, c.docstring]",
+] + [
+    # One per module-owned label: the incremental writer's per-module purge matches on
+    # `_module` once per changed module, which without these is a label scan per label per
+    # module -- quadratic on a full push (#171).
+    f"CREATE INDEX {label.lower()}_module IF NOT EXISTS FOR (x:{label}) ON (x._module)"
+    for label in MODULE_OWNED_LABELS
 ]
 
 

--- a/codeanalyzer/neo4j/schema.py
+++ b/codeanalyzer/neo4j/schema.py
@@ -210,7 +210,7 @@ NODE_LABELS: List[NodeLabel] = [
     NodeLabel("Artifact", "Artifact", "id", {
         "id": "string", "path": "string", "format": "string",
         "roles": "string[]", "size_bytes": "integer", "sha256": "string",
-        "source": "string", "text_truncated": "boolean", "extraction": "string",
+        "source": "string", "extraction": "string",
     }),
     NodeLabel("Package", "Package", "id", {
         "id": "string", "ecosystem": "string", "name": "string",

--- a/codeanalyzer/options/options.py
+++ b/codeanalyzer/options/options.py
@@ -43,7 +43,6 @@ class AnalysisOptions:
     clear_cache: bool = False
     verbosity: int = 0
     entrypoint_rules: Tuple[Path, ...] = ()
-    # Artifact text-capture controls (#157 follow-up): whether to capture
-    # `source` at all, and the per-file byte cap before it truncates.
+    # Artifact text capture (#157 follow-up): whether to capture `source` at
+    # all. There is no byte cap -- `source` is the whole file or "" (#172).
     artifact_text: bool = True
-    artifact_text_max_bytes: int = 262144

--- a/codeanalyzer/schema/py_schema.py
+++ b/codeanalyzer/schema/py_schema.py
@@ -512,9 +512,8 @@ class PyArtifact(BaseModel):
     format: str  # toml|yaml|json|ini|properties|requirements|dockerfile|text|binary
     roles: List[str] = []
     size_bytes: int = 0
-    sha256: str = ""  # always the full file's hash, even when source is truncated/empty
-    source: str = ""  # verbatim by default; "" for binary or when capture is disabled
-    text_truncated: bool = False  # True when `source` is a prefix, not the full file
+    sha256: str = ""  # always the full file's hash, even when source is empty
+    source: str = ""  # the WHOLE file, or "" for binary / when capture is disabled -- never a prefix
     extraction: str = "none"  # none|partial|full
     config_keys: List[PyConfigKey] = []  # flattened config keys (#152); [] when not namespace-eligible
 

--- a/docs/skills/analyzing-canpy-graphs/references/vocabulary.md
+++ b/docs/skills/analyzing-canpy-graphs/references/vocabulary.md
@@ -14,7 +14,7 @@
 | `PyAttribute` | `id` | _module, docstring, end_line, id, initializer, name, start_line, type |
 | `PyVariable` | `id` | _module, end_line, id, initializer, name, scope, start_line, type |
 | `PyBodyNode` | `id` (GLOBAL ordinal) | _module, arguments_json, call_node, end_line, id, is_constructor_call, kind, method_name, receiver_expr, receiver_type, return_type, start_line, var |
-| `Artifact` | `id` (`can://artifact/…`) | extraction, format, id, path, roles, sha256, size_bytes, source, text_truncated — **language-neutral, no Py prefix by design**; every non-`.py` file is inventoried (never-drop), binaries with empty source |
+| `Artifact` | `id` (`can://artifact/…`) | extraction, format, id, path, roles, sha256, size_bytes, source — **language-neutral, no Py prefix by design**; every non-`.py` file is inventoried (never-drop), binaries with empty source. `source` is the WHOLE file or `""` (binary, or `--no-artifact-text`) — never a prefix, so it needs no companion flag to be trusted |
 | `Package` | `id` (purl `pkg:pypi/<name>`, `<name>` PEP 503 normalized: lowercase, `[-_.]+` → `-`, so always `pkg:pypi/pyyaml`, never `pkg:pypi/PyYAML`) | ecosystem, id, name — language-neutral |
 
 `PyBodyNode.kind`: `entry`, `exit`, `statement`, `branch`, `loop`, `return`,

--- a/schema.neo4j.json
+++ b/schema.neo4j.json
@@ -164,7 +164,6 @@
         "size_bytes": "integer",
         "sha256": "string",
         "source": "string",
-        "text_truncated": "boolean",
         "extraction": "string"
       }
     },

--- a/schema.neo4j.json
+++ b/schema.neo4j.json
@@ -510,6 +510,12 @@
   "indexes": [
     "CREATE INDEX py_callable_name IF NOT EXISTS FOR (c:PyCallable) ON (c.name)",
     "CREATE INDEX py_class_name IF NOT EXISTS FOR (c:PyClass) ON (c.name)",
-    "CREATE FULLTEXT INDEX py_code_fts IF NOT EXISTS FOR (c:PyCallable) ON EACH [c.code, c.docstring]"
+    "CREATE FULLTEXT INDEX py_code_fts IF NOT EXISTS FOR (c:PyCallable) ON EACH [c.code, c.docstring]",
+    "CREATE INDEX pymodule_module IF NOT EXISTS FOR (x:PyModule) ON (x._module)",
+    "CREATE INDEX pyclass_module IF NOT EXISTS FOR (x:PyClass) ON (x._module)",
+    "CREATE INDEX pycallable_module IF NOT EXISTS FOR (x:PyCallable) ON (x._module)",
+    "CREATE INDEX pyattribute_module IF NOT EXISTS FOR (x:PyAttribute) ON (x._module)",
+    "CREATE INDEX pyvariable_module IF NOT EXISTS FOR (x:PyVariable) ON (x._module)",
+    "CREATE INDEX pybodynode_module IF NOT EXISTS FOR (x:PyBodyNode) ON (x._module)"
   ]
 }

--- a/test/test_artifact_discovery.py
+++ b/test/test_artifact_discovery.py
@@ -1,7 +1,7 @@
 """Task 2: every file becomes a PyArtifact node except `.py` files and ignored
 dirs (never-drop inventory, issue #157 follow-up). Rule-matched files keep
 their format/roles; unmatched files fall back to text/unknown (or binary).
-Also covers the text-capture controls (`capture_text`/`text_max_bytes`)."""
+Also covers the text-capture control (`capture_text`)."""
 import hashlib
 from pathlib import Path
 from codeanalyzer.schema import model_dump
@@ -175,36 +175,17 @@ def test_py_files_never_become_artifacts(tmp_path):
     assert "setup.py" in arts and arts["setup.py"].roles == ["dependency-manifest"]
 
 
-def test_text_max_bytes_caps_source_and_flags_truncation(tmp_path):
-    content = "0123456789abcdefGHIJ"  # 21 bytes, past a 16-byte cap
+def test_source_is_the_whole_file_however_large(tmp_path):
+    """#172: there is no byte cap. `source` is the whole file or "" -- never a
+    prefix -- so a large file round-trips verbatim, multi-byte chars included."""
+    content = ("café " * 100_000) + "tail"  # ~600 KB, well past the old 262144 cap
     _mk(tmp_path, "notes.md", content)
     raw = content.encode("utf-8")
-    arts = discover_artifacts(tmp_path, "a", text_max_bytes=16)
-    art = arts["notes.md"]
-    assert art.source == content[:16]
-    assert art.text_truncated is True
+    assert len(raw) > 262144
+    art = discover_artifacts(tmp_path, "a")["notes.md"]
+    assert art.source == content
     assert art.sha256 == hashlib.sha256(raw).hexdigest()   # sha256 always full-file
     assert art.size_bytes == len(raw)
-
-
-def test_text_max_bytes_never_raises_on_split_multibyte_char(tmp_path):
-    """A cap that lands mid-codepoint must decode cleanly, never raise --
-    back off to the last clean char boundary (errors='ignore' on the prefix)."""
-    raw = ("a" * 15 + "é" + "extra-tail").encode("utf-8")  # 'é' straddles byte 16
-    (tmp_path / "notes.md").write_bytes(raw)
-    arts = discover_artifacts(tmp_path, "a", text_max_bytes=16)
-    art = arts["notes.md"]
-    assert art.text_truncated is True
-    assert art.source == "a" * 15
-    assert len(art.source.encode("utf-8")) <= 16
-    assert art.sha256 == hashlib.sha256(raw).hexdigest()
-
-
-def test_file_under_cap_is_not_truncated(tmp_path):
-    _mk(tmp_path, "notes.md", "short\n")
-    arts = discover_artifacts(tmp_path, "a", text_max_bytes=16)
-    assert arts["notes.md"].source == "short\n"
-    assert arts["notes.md"].text_truncated is False
 
 
 def test_capture_text_false_empties_source_everywhere_else_identical(tmp_path):
@@ -216,33 +197,20 @@ def test_capture_text_false_empties_source_everywhere_else_identical(tmp_path):
     assert set(with_text) == set(without_text)
     for path in with_text:
         b = without_text[path]
-        assert b.source == "" and b.text_truncated is False
+        assert b.source == ""
         a_dict = model_dump(with_text[path])
         b_dict = model_dump(b)
         a_dict["source"] = b_dict["source"] = ""
-        a_dict["text_truncated"] = b_dict["text_truncated"] = False
         assert a_dict == b_dict
 
 
-def test_dependency_manifest_exempt_from_text_max_bytes(tmp_path):
-    """#157 review fix: a dependency-manifest's source IS the extraction
-    input -- the byte cap targets bulk/incidental assets, never manifests.
-    A cap far below the file's real size must not truncate it."""
-    content = '[project]\ndependencies = ["requests"]\n'  # > 16 bytes
-    _mk(tmp_path, "pyproject.toml", content)
-    arts = discover_artifacts(tmp_path, "a", text_max_bytes=16)
-    art = arts["pyproject.toml"]
-    assert art.source == content
-    assert art.text_truncated is False
-
-
-def test_dependency_manifest_still_empty_source_with_capture_text_false(tmp_path):
-    """The manifest exemption is from the byte CAP only -- capture_text=False
-    still empties source for manifests exactly like everything else."""
+def test_dependency_manifest_source_is_empty_with_capture_text_false(tmp_path):
+    """capture_text=False empties source for manifests exactly like everything
+    else. (The old cap exemption for dependency-manifests went away with the
+    cap itself -- every decodable file is captured in full now, #172.)"""
     _mk(tmp_path, "pyproject.toml", '[project]\ndependencies = ["requests"]\n')
-    arts = discover_artifacts(tmp_path, "a", capture_text=False, text_max_bytes=16)
-    art = arts["pyproject.toml"]
-    assert art.source == "" and art.text_truncated is False
+    arts = discover_artifacts(tmp_path, "a", capture_text=False)
+    assert arts["pyproject.toml"].source == ""
 
 
 def test_discovers_terraform_flaskenv_properties_and_generic_ini(tmp_path):

--- a/test/test_artifact_models.py
+++ b/test/test_artifact_models.py
@@ -33,7 +33,6 @@ def test_models_round_trip():
     back = model_validate_json(PyApplication, model_dump_json(app))
     assert back.artifacts["pyproject.toml"].kind == "artifact"
     assert back.artifacts["pyproject.toml"].extraction == "none"
-    assert back.artifacts["pyproject.toml"].text_truncated is False
     assert back.dependencies[0].locked_version is None
     assert back.unresolved_imports[0].bound_to == "pyyaml"
 

--- a/test/test_artifact_pipeline.py
+++ b/test/test_artifact_pipeline.py
@@ -42,33 +42,29 @@ def test_resolve_installed_flag_default_off():
     assert AnalysisOptions(input=Path(".")).resolve_installed is False
 
 
-def test_artifact_text_flags_defaults():
-    opts = AnalysisOptions(input=Path("."))
-    assert opts.artifact_text is True
-    assert opts.artifact_text_max_bytes == 262144
+def test_artifact_text_flag_default():
+    assert AnalysisOptions(input=Path(".")).artifact_text is True
 
 
-def test_artifact_text_options_thread_through_core(tmp_path):
-    """core.py must pass artifact_text/artifact_text_max_bytes to
-    discover_artifacts -- verified end to end, not just at the discovery unit."""
+def test_artifact_text_option_threads_through_core(tmp_path):
+    """core.py must pass artifact_text to discover_artifacts -- verified end to
+    end, not just at the discovery unit. #172: capture is whole-file or empty,
+    with no cap in between."""
     proj = tmp_path / "proj"
     proj.mkdir()
-    (proj / "notes.md").write_text("0123456789abcdefGHIJ")  # 21 bytes
+    content = "0123456789abcdefGHIJ" * 20_000  # 400 KB, past the old 262144 cap
+    (proj / "notes.md").write_text(content)
 
-    capped = Codeanalyzer(AnalysisOptions(
-        input=proj, analysis_level=1, no_venv=True, cache_dir=tmp_path / "cache-capped",
-        artifact_text_max_bytes=16,
+    whole = Codeanalyzer(AnalysisOptions(
+        input=proj, analysis_level=1, no_venv=True, cache_dir=tmp_path / "cache-whole",
     )).analyze().application
-    art = capped.artifacts["notes.md"]
-    assert art.text_truncated is True
-    assert len(art.source.encode("utf-8")) <= 16
+    assert whole.artifacts["notes.md"].source == content
 
     no_text = Codeanalyzer(AnalysisOptions(
         input=proj, analysis_level=1, no_venv=True, cache_dir=tmp_path / "cache-no-text",
         artifact_text=False,
     )).analyze().application
     assert no_text.artifacts["notes.md"].source == ""
-    assert no_text.artifacts["notes.md"].text_truncated is False
 
 
 def test_config_keys_present_and_identical_across_levels(tmp_path):

--- a/test/test_dependency_view.py
+++ b/test/test_dependency_view.py
@@ -195,16 +195,17 @@ def _big_lock_text(min_bytes: int) -> str:
     return "".join(parts)
 
 
-def test_large_lock_parses_all_pins_under_default_text_cap(tmp_path):
-    """#157 review fix: a lock bigger than the default 262144-byte cap must
-    still parse in full -- dependency-manifest artifacts are exempt from
-    text_max_bytes at discovery, and extraction reads the file fresh besides."""
+def test_large_lock_parses_all_pins_and_is_captured_whole(tmp_path):
+    """#157 review fix, now unconditional (#172): a lock bigger than the old
+    262144-byte cap parses in full AND is stored in full -- there is no cap and
+    so no manifest exemption to rely on, and extraction reads the file fresh
+    besides."""
     text = _big_lock_text(300_000)
     assert len(text.encode("utf-8")) > 262144
     (tmp_path / "uv.lock").write_text(text)
     package_count = text.count("[[package]]")
-    arts = discover_artifacts(tmp_path, "app")  # default text_max_bytes
-    assert arts["uv.lock"].text_truncated is False
+    arts = discover_artifacts(tmp_path, "app")
+    assert arts["uv.lock"].source == text
     deps, _ = build_dependency_view(arts, {}, tmp_path, None, False)
     pinned = {d.name for d in deps if d.locked_version}
     assert len(pinned) == package_count

--- a/test/test_neo4j_artifacts.py
+++ b/test/test_neo4j_artifacts.py
@@ -5,7 +5,6 @@ from codeanalyzer.neo4j.schema import NODE_LABELS, REL_TYPES
 def test_catalog_has_neutral_vocabulary():
     labels = {n.label: n for n in NODE_LABELS}
     assert labels["Artifact"].key == "id" and labels["Package"].key == "id"
-    assert labels["Artifact"].properties["text_truncated"] == "boolean"
     rels = {r.type for r in REL_TYPES}
     assert {"HAS_ARTIFACT", "DECLARES_DEPENDENCY", "LOCKS",
             "PY_PROVIDES", "PY_UNRESOLVED_IMPORT"} <= rels
@@ -33,7 +32,6 @@ def test_rows_projected(tmp_path):
         n for n in rows.nodes
         if n.labels[0] == "Artifact" and n.value == "can://artifact/p/pyproject.toml"
     )
-    assert pyproject_node.props["text_truncated"] is False
     rel_types = {e.type for e in rows.edges}
     assert {"HAS_ARTIFACT", "DECLARES_DEPENDENCY", "PY_PROVIDES"} <= rel_types
 

--- a/test/test_neo4j_bolt.py
+++ b/test/test_neo4j_bolt.py
@@ -128,13 +128,13 @@ def test_full_run_does_not_prune_another_applications_modules(driver, cfg):
     """Regression for #45: a full-run push for one application must not prune the
     modules of a *different* application sharing the database."""
     app_a, sig_to_id_a = make_sample_app()
-    bolt_writer(project(app_a, "app-a", sig_to_id_a), cfg, full_run=True)
+    bolt_writer(project(app_a, "app-a", sig_to_id_a), cfg, full_run=True, eager=True)
     before = _num(driver, "MATCH (:PyApplication {name:'app-a'})-[:PY_HAS_MODULE]->(m) RETURN count(m)")
     assert before > 0
 
     # A full-run push for a different application must leave app-a untouched.
     app_b, sig_to_id_b = _single_module_app()
-    bolt_writer(project(app_b, "app-b", sig_to_id_b), cfg, full_run=True)
+    bolt_writer(project(app_b, "app-b", sig_to_id_b), cfg, full_run=True, eager=True)
 
     after = _num(driver, "MATCH (:PyApplication {name:'app-a'})-[:PY_HAS_MODULE]->(m) RETURN count(m)")
     assert after == before, "full-run push for app-b pruned app-a's modules (#45)"
@@ -151,15 +151,16 @@ def test_re_pushing_identical_analysis_is_idempotent(driver, cfg):
 
 
 def test_a_full_run_prunes_a_module_whose_source_vanished(driver, cfg):
+    """Pruning is destructive, so it is an --eager behaviour (#171)."""
     app0, sig_to_id0 = make_sample_app()
-    bolt_writer(project(app0, "sample-app", sig_to_id0), cfg, full_run=True)
+    bolt_writer(project(app0, "sample-app", sig_to_id0), cfg, full_run=True, eager=True)
 
     # Drop one module from a fresh app and re-push as a full run.
     app, sig_to_id = make_sample_app()
     victim = sorted(app.symbol_table.keys())[0]
     del app.symbol_table[victim]
     rows = project(app, "sample-app", sig_to_id)
-    bolt_writer(rows, cfg, full_run=True)
+    bolt_writer(rows, cfg, full_run=True, eager=True)
 
     # The victim's module-scoped nodes are gone.
     assert _num(driver, "MATCH (n {_module:$m}) RETURN count(n)", m=victim) == 0
@@ -169,3 +170,44 @@ def test_a_full_run_prunes_a_module_whose_source_vanished(driver, cfg):
     # compare only _module-tagged nodes.)
     module_scoped = sum(1 for n in rows.nodes if "_module" in n.props)
     assert _num(driver, "MATCH (n) WHERE n._module IS NOT NULL RETURN count(n)") == module_scoped
+
+
+def test_a_push_never_touches_a_sibling_analyzers_nodes(driver, cfg):
+    """Regression for #171: `_module` is a shared convention — codeanalyzer-java and
+    codeanalyzer-typescript set it on their nodes too. A python push for a module whose
+    file key collides with a sibling analyzer's must leave that analyzer's graph intact."""
+    file_key = "appb/main.py"
+    with driver.session() as session:
+        session.run(
+            "CREATE (a:TsModule {_module: $m, id: 'ts-1'})"
+            "-[:TS_HAS_METHOD]->(b:TsCallable {_module: $m, id: 'ts-2'})",
+            m=file_key,
+        )
+
+    app_b, sig_to_id_b = _single_module_app(file_key)
+    bolt_writer(project(app_b, "app-b", sig_to_id_b), cfg, full_run=True, eager=True)
+
+    assert _num(driver, "MATCH (n:TsModule) RETURN count(n)") == 1
+    assert _num(driver, "MATCH (n:TsCallable) RETURN count(n)") == 1
+    assert _num(driver, "MATCH (:TsModule)-[r:TS_HAS_METHOD]->(:TsCallable) RETURN count(r)") == 1
+
+
+def test_a_lazy_push_deletes_nothing(driver, cfg):
+    """#171: a push is additive by default. Re-pushing an app with a module and a
+    callable removed must leave both in the graph — only --eager reconciles them."""
+    app0, sig_to_id0 = make_sample_app()
+    rows0 = project(app0, "sample-app", sig_to_id0)
+    bolt_writer(rows0, cfg, full_run=True)
+    before = _num(driver, "MATCH (n) WHERE n._module IS NOT NULL RETURN count(n)")
+
+    app, sig_to_id = make_sample_app()
+    victim = sorted(app.symbol_table.keys())[0]
+    del app.symbol_table[victim]
+    bolt_writer(project(app, "sample-app", sig_to_id), cfg, full_run=True)
+
+    assert _num(driver, "MATCH (n) WHERE n._module IS NOT NULL RETURN count(n)") == before
+    assert _num(driver, "MATCH (n) WHERE n._module = $m RETURN count(n)", m=victim) > 0
+
+    # ...and --eager still reconciles it.
+    bolt_writer(project(app, "sample-app", sig_to_id), cfg, full_run=True, eager=True)
+    assert _num(driver, "MATCH (n) WHERE n._module = $m RETURN count(n)", m=victim) == 0


### PR DESCRIPTION
Two related contract fixes on the Neo4j/artifact surface. Both close their issue.

## `fix(neo4j)`: scope the Bolt purge, and gate every delete on `--eager` (#171)

The per-module purge matched `MATCH (x {_module: $m})` with no label. `_module` is a shared
convention, not a python-private one — codeanalyzer-java and codeanalyzer-typescript set it on
their nodes too — so wherever a python module and a sibling analyzer's module shared a file key,
a python push detach-deleted that sibling's nodes and their relationships. Silently: no error,
no log line.

Both statements are now anchored on the python-owned labels, derived from the schema catalog
(`MODULE_OWNED_LABELS`) rather than hand-listed, so a new module-scoped label is covered without
a second list to maintain.

A push also no longer deletes anything by default. The per-module purge and the full-run orphan
prune are the only destructive steps, and both now run under `--eager`; a default `--lazy` push
is purely additive. The cost is staleness — a declaration or call edge the source no longer has
survives until an `--eager` push reconciles it — and the gain is that an incremental push into a
shared database cannot destroy anything. This matches codeanalyzer-typescript and answers spec
§9 Q2 of `2026-09-02-prune-scope-on-can-id-prefix.md` for python.

Also adds an `_module` index per module-owned label: the purge matched on `_module` once per
changed module against an unindexed scan, which is quadratic on a full push.

**Interim by design.** `codellm-devkit/.github#50` supersedes both the label anchor and these
indexes with `can://` id-prefix scoping; this closes the live data-loss bug now, in the same
shape codeanalyzer-java landed in its #213.

## `feat(artifacts)!`: an artifact's `source` is the whole file, or nothing (#172)

**BREAKING.** `PyArtifact.text_truncated`, `--artifact-text-max-bytes`, and the Neo4j
`:Artifact.text_truncated` property are removed. `source` is the whole file, or `""` because the
file is binary or `--no-artifact-text` was passed. It is never a prefix.

A truncated `source` read exactly like a complete small file, so every consumer had to carry the
flag beside the text to know whether the text could be trusted. The flag couldn't carry that
meaning anyway: `text_truncated: false` covered both "whole file" and "capture off". And it
bought little — on `microsoft/vscode` the cap fired on 32 of 4,953 artifacts (0.6%). `sha256`
and `size_bytes` were always full-file, so no integrity check changes.

python's `dependency-manifest` exemption goes with the cap: with nothing to be exempt from,
every decodable file is simply captured in full.

Spec: `codellm-devkit/.github` `docs/design/specs/2026-09-02-artifact-source-whole-file.md`
Epic: codellm-devkit/.github#51 — codeanalyzer-java#214 is the remaining child.

## Migration

- reading `text_truncated`: delete the check. `source` is now trustworthy whenever it is non-empty.
- passing `--artifact-text-max-bytes`: remove it. Use `--no-artifact-text` to drop the payload.
- relying on a Bolt push to remove stale nodes: pass `--eager`.

## Verification

- full suite `471 passed, 8 skipped`
- container-gated Neo4j suite `6 passed` (`RUN_CONTAINER_TESTS=1`), including a new regression
  test asserting a foreign `_module`-tagged node survives a python push — it fails on the parent
  commit with `assert 0 == 1`
- end-to-end: a 600 KB artifact round-trips whole (`source` 600000 bytes == `size_bytes`), with
  no `text_truncated` key emitted
- `schema.neo4j.json` and the README help block regenerated; `update_readme.py --check` clean

Closes #171
Closes #172
