### PR TITLE
feat(schema): body nodes and parameters carry their id in analysis.json

### DIFF
--- a/.claude/SCHEMA_DECISIONS.md
+++ b/.claude/SCHEMA_DECISIONS.md
@@ -412,3 +412,31 @@ side) and `docs/design/specs/2026-08-28-config-use-edge-design.md` (the
   `points-to` edge whose def is not a `Name = <str Constant>` shape and so
   unfilterably kills the closure at `-a 4` while `-a 3` (ssa-only by
   construction) resolves cleanly.
+
+## 2026-09-05 — `BodyNode.id` and `PyCallableParameter.id` (issue #176, epic .github#56)
+
+Spec: `codellm-devkit/.github` → `docs/design/specs/2026-09-05-body-node-id-in-analysis-json.md`.
+
+- **Body nodes carry the global ordinal in JSON.** `BodyNode.id` is
+  `<callable-id>@<local>` — the value `neo4j/project.py` already merges
+  `:PyBodyNode` on. The `@`-rule lives once, in `schema/ids.py:global_ordinal`
+  (synthetic keys `@entry`/`@formal_in:0` concatenate, positional keys `15:2`/
+  `15:2/actual_in:0` gain a `@`); `IdentityMap.global_id` and the projector's
+  `_global_ordinal` delegate to it, so the two projections cannot drift.
+  Stamped by `ids.stamp_body_ids` at the end of each body emitter
+  (`populate_l1_body`, `emit_l3_body`, `emit_l4`), not threaded through the
+  four construction sites — one pass per level, idempotent under cache reuse.
+- **Parameters name their L4 formal.** `PyCallableParameter.id` is
+  `<callable-id>@formal_in:<i>` by position in `parameters`. Below `-a 4` it is
+  a forward reference (the vertex is not in `body` yet), accepted on the same
+  footing as a `call` node's `callee` naming a callable. The rule holds
+  because `access_paths._param_names` and the symbol table walk parameters in
+  the same order (`posonlyargs, args, vararg, kwonlyargs, kwarg`) and
+  `build_formals` allocates declared params before captures/globals; the L4
+  agreement test pins `body["@formal_in:i"].of == parameters[i].name`.
+- **Spine, not leaf.** Java and typescript mint the same value for Neo4j and
+  the grammar is keystone-defined, so the field is a spine addition tracked
+  per analyzer under epic .github#56. `PyCallsite` (legacy, #120) and
+  class attributes/variables (signature-minted Neo4j ids, being redone under
+  #173) do not get one. `schema_version` stays `2.0.0`; graph contract
+  unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `BodyNode.id` and `PyCallableParameter.id` in `analysis.json` (#176). A body
+  node's `id` is the global ordinal `<callable-id>@<local>` the Neo4j projection
+  already merges `:PyBodyNode` on, present at every level the node exists; a
+  parameter's `id` is `<callable-id>@formal_in:<i>` for its position `i`, the
+  level-4 `formal_in` vertex that carries it (a forward reference below `-a 4`).
+  Both projections now name a body node the same way, so consumers stop
+  recomposing the `can://` grammar themselves. Additive; `schema_version`
+  and the graph contract are unchanged.
+
 ## [1.4.0] - 2026-09-02
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -513,7 +513,8 @@ A **callable** (function or method) carries its own CPG, keyed by node id:
   "body": {                                       // node id → node
     "@entry": { "kind": "entry" },
     "6:4":    { "kind": "statement", "span": { … } },
-    "6:8":    { "kind": "call", "span": { … }, "callee": "can://…/helper(x)" },  // callee null until L2
+    "6:8":    { "id": "can://…/main()@6:8", "kind": "call", "span": { … },
+                "callee": "can://…/helper(x)" },                                // callee null until L2
     "@formal_in:0":    { "kind": "formal_in", "of": "a" },              // L4 param vertices
     "6:4/actual_in:0": { "kind": "actual_in", "of": "a", "parent": "6:4" },
     "@exit":  { "kind": "exit" }

--- a/codeanalyzer/dataflow/builder.py
+++ b/codeanalyzer/dataflow/builder.py
@@ -43,6 +43,7 @@ from codeanalyzer.dataflow.alias import TypeBasedAliasOracle
 from codeanalyzer.dataflow.pdg import build_pdg
 from codeanalyzer.dataflow.sdg import ProgramGraphsIR, assemble_sdg
 from codeanalyzer.dataflow.summaries import CallSite, FunctionInfo, compute_summaries
+from codeanalyzer.schema.ids import stamp_body_ids
 from codeanalyzer.schema.py_schema import PyApplication, PyCallable, PyClass, PyModule
 from codeanalyzer.utils import logger
 
@@ -333,6 +334,7 @@ def emit_l3_body(
                     for e in pdg.edges
                     if e.type == "DDG"
                 ]
+            stamp_body_ids(pycallable)
 
 
 def build_program_graphs(
@@ -538,6 +540,7 @@ def emit_l4(
             pycallable.body[im.local(pn.id)] = BodyNode(
                 kind=pn.kind, of=pn.var, parent=parent
             )
+        stamp_body_ids(pycallable)
 
     # (b/c/d) SDG edges → summary / param_in / param_out; CALL dropped.
     for e in ir.sdg_edges:

--- a/codeanalyzer/dataflow/identity.py
+++ b/codeanalyzer/dataflow/identity.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Dict, Iterable, Optional, Tuple
 
+from codeanalyzer.schema.ids import global_ordinal
+
 
 class IdentityMap:
     def __init__(self, callable_id: str, id_to_local: Dict[int, str]):
@@ -83,9 +85,7 @@ class IdentityMap:
 
     def global_id(self, node_id: int) -> str:
         """Fully addressable id: ``"<callable-id>@<local>"``."""
-        loc = self._map[node_id]
-        # local statements are "line:col"; bookends already carry the leading "@"
-        return f"{self._callable_id}{loc}" if loc.startswith("@") else f"{self._callable_id}@{loc}"
+        return global_ordinal(self._callable_id, self._map[node_id])
 
     def node_ids(self) -> Iterable[int]:
         return self._map.keys()

--- a/codeanalyzer/neo4j/project.py
+++ b/codeanalyzer/neo4j/project.py
@@ -47,7 +47,7 @@ from codeanalyzer.schema import (
     PyModule,
     PyVariableDeclaration,
 )
-from codeanalyzer.schema.ids import application_id, purl_pypi
+from codeanalyzer.schema.ids import application_id, global_ordinal, purl_pypi
 from codeanalyzer.schema.py_schema import PyDecorator
 
 
@@ -128,11 +128,7 @@ def _global_ordinal(callable_id: str, local_key: str) -> str:
     This MUST agree with :meth:`IdentityMap.global_id` for the same node, so the
     JSON ``body``/``cfg`` projection and this Neo4j projection land on one node
     identity (two-projection agreement)."""
-    return (
-        f"{callable_id}{local_key}"
-        if local_key.startswith("@")
-        else f"{callable_id}@{local_key}"
-    )
+    return global_ordinal(callable_id, local_key)
 
 
 def _body_ref(callable_id: str, local_key: str) -> NodeRef:

--- a/codeanalyzer/schema/ids.py
+++ b/codeanalyzer/schema/ids.py
@@ -23,6 +23,23 @@ def ordinal_id(callable_id: str, tag: str) -> str:
     return f"{callable_id}@{tag}"
 
 
+def global_ordinal(callable_id: str, local_key: str) -> str:
+    """The GLOBAL ordinal id of a body node from its LOCAL key: synthetic keys
+    (`@entry`, `@formal_in:0`) already carry the `@`; positional keys (`15:2`,
+    `15:2/actual_in:0`) get one. This is the :PyBodyNode merge key and, since
+    #176, `BodyNode.id` — the one implementation both projections share."""
+    return f"{callable_id}{local_key}" if local_key.startswith("@") else f"{callable_id}@{local_key}"
+
+
+def stamp_body_ids(callable) -> None:
+    """Stamp `id` on every body node and parameter of one callable (#176).
+    Idempotent; each body emitter calls it after writing its nodes."""
+    for key, node in callable.body.items():
+        node.id = global_ordinal(callable.id, key)
+    for i, p in enumerate(callable.parameters or []):
+        p.id = ordinal_id(callable.id, f"formal_in:{i}")
+
+
 def artifact_id(app_name: str, rel_path: str) -> str:
     """Language-neutral artifact id: ``can://artifact/<app>/<rel-path>``.
 

--- a/codeanalyzer/schema/l1_body.py
+++ b/codeanalyzer/schema/l1_body.py
@@ -1,6 +1,7 @@
 """L1 body population: materialize `call` nodes from existing call sites.
 `callee` is left None here — the sanctioned null→id refinement happens at L2."""
 from __future__ import annotations
+from codeanalyzer.schema.ids import stamp_body_ids
 from codeanalyzer.schema.py_schema import PyApplication, PyClass, PyCallable, BodyNode, Span, byte_offsets
 
 def _do_callable(source: str, c: PyCallable) -> None:
@@ -20,6 +21,7 @@ def _do_callable(source: str, c: PyCallable) -> None:
             is_constructor_call=cs.is_constructor_call,
             arguments=list(cs.arguments or []),
         )
+    stamp_body_ids(c)
     for ic in (c.callables or {}).values():
         _do_callable(source, ic)
     for icl in (c.types or {}).values():

--- a/codeanalyzer/schema/py_schema.py
+++ b/codeanalyzer/schema/py_schema.py
@@ -128,6 +128,9 @@ class BodyNode(BaseModel):
     """A node in a callable's `body`: an AST region (statement/call/branch/…) or
     a synthetic analysis vertex (entry/exit/formal_in/out/actual_in/out)."""
     kind: str
+    # #176: the GLOBAL ordinal id — `<callable-id>@<local>` — the same value the
+    # Neo4j projection merges :PyBodyNode on. Stamped by `ids.stamp_body_ids`.
+    id: str = ""
     span: Optional[Span] = None
     callee: Optional[str] = None   # only on `call` nodes; the sanctioned null→id slot
     of: Optional[str] = None       # param vertices: the variable/return they carry
@@ -287,6 +290,9 @@ class PyCallableParameter(BaseModel):
     """Represents a parameter of a Python callable (function/method)."""
 
     name: str
+    # #176: `<callable-id>@formal_in:<i>` for position i — the L4 formal_in vertex
+    # that carries this parameter. A forward reference below level 4.
+    id: str = ""
     type: Optional[str] = None
     default_value: Optional[str] = None
     decorators: List[PyDecorator] = []

--- a/docs/skills/analyzing-canpy-graphs/references/vocabulary.md
+++ b/docs/skills/analyzing-canpy-graphs/references/vocabulary.md
@@ -17,6 +17,10 @@
 | `Artifact` | `id` (`can://artifact/…`) | extraction, format, id, path, roles, sha256, size_bytes, source — **language-neutral, no Py prefix by design**; every non-`.py` file is inventoried (never-drop), binaries with empty source. `source` is the WHOLE file or `""` (binary, or `--no-artifact-text`) — never a prefix, so it needs no companion flag to be trusted |
 | `Package` | `id` (purl `pkg:pypi/<name>`, `<name>` PEP 503 normalized: lowercase, `[-_.]+` → `-`, so always `pkg:pypi/pyyaml`, never `pkg:pypi/PyYAML`) | ecosystem, id, name — language-neutral |
 
+In `analysis.json` the same value is `body[<local>].id` on every body node, and
+`parameters[i].id` is `<callable-id>@formal_in:<i>` — so a JSON-side node and its
+`:PyBodyNode` join on one string without recomposing the id.
+
 `PyBodyNode.kind`: `entry`, `exit`, `statement`, `branch`, `loop`, `return`,
 `raise`, `handler`, `call`, `formal_in`, `formal_out`, `actual_in`, `actual_out`.
 

--- a/test/test_v2_l1_body.py
+++ b/test/test_v2_l1_body.py
@@ -11,3 +11,20 @@ def test_l1_body_has_call_nodes_with_null_callee():
     node = fn.body["2:4"]
     assert node.kind == "call"
     assert node.callee is None  # L1: unresolved; backfilled at L2
+
+
+def test_l1_body_nodes_and_parameters_carry_global_ordinal_ids():
+    # #176: a body node's `id` is the global ordinal the Neo4j projection merges on;
+    # a parameter's `id` names the L4 formal_in vertex that will carry it.
+    from codeanalyzer.schema.assign_ids import assign_ids
+    from codeanalyzer.schema.py_schema import PyCallableParameter
+    cs = PyCallsite(method_name="g", start_line=2, start_column=4, end_line=2,
+                    end_column=7, callee_signature="m.g")
+    fn = PyCallable(name="f", path="m.py", signature="m.f", call_sites=[cs],
+                    parameters=[PyCallableParameter(name="a"), PyCallableParameter(name="b")])
+    mod = PyModule(file_path="m.py", module_name="m", functions={"f": fn})
+    app = PyApplication(symbol_table={"m.py": mod})
+    assign_ids(app, "myapp")
+    populate_l1_body(app)
+    assert fn.body["2:4"].id == fn.id + "@2:4"
+    assert [p.id for p in fn.parameters] == [fn.id + "@formal_in:0", fn.id + "@formal_in:1"]

--- a/test/test_v2_two_projection_agreement.py
+++ b/test/test_v2_two_projection_agreement.py
@@ -251,3 +251,41 @@ def test_projected_code_property_is_the_module_source_span_slice():
     # the sample app has functions, methods, an inner class and a subclass —
     # if we checked fewer than that, the walk itself is broken.
     assert checked >= 6
+
+
+# ----------------------------------------------------------------------------------------------
+# #176: the JSON `body` nodes and `parameters` carry the same id the projection merges on.
+# ----------------------------------------------------------------------------------------------
+
+
+def test_l3_body_node_ids_equal_projected_pybodynode_keys(tmp_path):
+    app, sig_to_id, mod = _build_l3_app(tmp_path)
+    c = next(iter(mod.functions.values()))
+    rows = project(app, "app", sig_to_id)
+    emitted = {
+        n.value for n in rows.nodes
+        if n.labels[0] == "PyBodyNode" and n.value.startswith(c.id + "@")
+    }
+    assert {n.id for n in c.body.values()} == emitted
+    for k, n in c.body.items():
+        assert n.id == _global_ordinal(c.id, k)
+    # a call node's `id` is a body id, its `callee` a callable id — never the same string
+    for n in c.body.values():
+        if n.kind == "call":
+            assert n.id != n.callee
+
+
+def test_l4_param_vertex_ids_and_parameter_ids_agree(tmp_path):
+    app, sig_to_id, id_fn, caller_fn = _build_l4_app(tmp_path)
+    rows = project(app, "app", sig_to_id)
+    keys = {n.value for n in rows.nodes if n.labels[0] == "PyBodyNode"}
+    for fn in (id_fn, caller_fn):
+        for k, n in fn.body.items():
+            assert n.id == _global_ordinal(fn.id, k)
+            assert n.id in keys
+        # parameters[i].id names the formal_in vertex at position i, in list order
+        for i, p in enumerate(fn.parameters):
+            assert p.id == f"{fn.id}@formal_in:{i}"
+            vertex = fn.body[f"@formal_in:{i}"]
+            assert vertex.id == p.id
+            assert vertex.of == p.name


### PR DESCRIPTION
Closes #176. Spec: codellm-devkit/.github `docs/design/specs/2026-09-05-body-node-id-in-analysis-json.md` (epic codellm-devkit/.github#56).

`BodyNode.id` is the global ordinal `<callable-id>@<local>` the Neo4j projection already merges `:PyBodyNode` on, present at every level the node exists. `PyCallableParameter.id` is `<callable-id>@formal_in:<i>` for position `i`, the level-4 vertex that carries it. The `@` rule now lives once in `schema/ids.py:global_ordinal`; `IdentityMap.global_id` and the projector delegate to it. One stamp pass runs at the end of each body emitter (L1, L3, L4).

Additive. `schema_version` and the graph contract unchanged.

Gates: `pytest` 474 passed, 8 skipped. L1⊆L2⊆L3⊆L4 on a fixture. Diff against 1.4.0 output on the same fixture: only `id` keys added. New tests: L1 stamp, L3 body-id/merge-key parity, L4 `parameters[i].id == body["@formal_in:i"].id` with `of == name`.
