### PR TITLE
fix(neo4j): resolve PY_EXTENDS bases per module so the edge is actually emitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recomposing the `can://` grammar themselves. Additive; `schema_version`
   and the graph contract are unchanged.
 
+### Fixed
+
+- `PY_EXTENDS` is now actually emitted (#178). The projector handed the written
+  base spelling (`Base`, `views.View`) to a lookup keyed by signature
+  (`pkg.mod.Base`), so every inheritance edge was dropped as dangling and no
+  graph since 2.0.0 carried one. Bases now resolve per module: a class declared
+  in the module or reachable through its import table lands on that class's
+  `can://` id; anything else lands on an `@external` ghost with the same id
+  shape call targets use. Relative imports resolve through `resolved_module`
+  for entrypoint base matching too.
+
 ## [1.4.0] - 2026-09-02
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ levels are cumulative and additive — `analysis.json(-a 1) ⊆ … ⊆ analysis
 | **1** | `-a 1` (default) | Symbol table, Jedi call graph, and `call` nodes in each callable's `body` | `body` calls (`callee: null`) |
 | **2** | `-a 2` | Defuse-linker call-graph enrichment; each call's `callee` backfilled to a `can://` id | `call_graph`, `body` callees |
 | **3** | `-a 3` | Native **intraprocedural** CFG/CDG/DDG (syntactic, name-equality, `prov: ["ssa"]`) | `cfg`, `cdg`, `ddg`, `@entry`/`@exit` on each callable |
-| **4** | `-a 4` | **Interprocedural** SDG: synthetic param vertices, alias-aware DDG (`prov: ["points-to"]`) | `param_in`, `param_out`, `summary`, semantic `ddg` |
+| **4** | `-a 4` | **Interprocedural** SDG: synthetic param vertices, alias-aware DDG (`prov: ["points-to"]`), port-wiring DDG between statements and param vertices (`prov: ["reaching-defs"]`) | `param_in`, `param_out`, `summary`, semantic `ddg` |
 
 `-a 1`/`-a 2` timings and output are unaffected by the heavier levels — nothing at level 3+ runs
 unless requested. Flag gating: `--graphs sdg` requires `-a 4`; `--graphs cfg,dfg,pdg` and
@@ -448,7 +448,11 @@ symbol-table signature by construction
 - **Points-to oracle (level 4):** the **Scalpel** may-alias oracle — `ScalpelAliasOracle`
   (`codeanalyzer/dataflow/scalpel_oracle.py`) — consumes Scalpel's SSA copy/const facts to answer
   `may_alias(path_a, path_b)`, adding the alias-aware DDG edges (`prov: ["points-to"]`) and the
-  interprocedural summaries. Scalpel is **vendored** — a `typed_ast`-free slice built into the
+  interprocedural summaries. Level 4 also wires the statement-level DDG to the param
+  vertices (def → `actual_in`, `actual_out` → call site, `formal_in` → use, def → `formal_out`)
+  with `prov: ["reaching-defs"]`; without those the SDG would be two disconnected graphs. So
+  `prov` takes three values: `ssa` (syntactic, L3), `reaching-defs` (port wiring, L4) and
+  `points-to` (alias-derived, L4). Scalpel is **vendored** — a `typed_ast`-free slice built into the
   package under `codeanalyzer/dataflow/scalpel/` — so it is the **default** level-4 oracle with no
   external dependency to install; the analyzer falls back to the built-in `TypeBasedAliasOracle`
   (Jedi-inferred types; unknown types conservatively alias) only when Scalpel can't resolve a

--- a/codeanalyzer/entrypoints/pipeline.py
+++ b/codeanalyzer/entrypoints/pipeline.py
@@ -90,7 +90,8 @@ def _base_resolver(mod: PyModule):
     aliases: Dict[str, str] = {}
     for imp in mod.imports or []:
         original = imp.alias or imp.name
-        aliases[imp.name] = imp.module if imp.module == original else f"{imp.module}.{original}"
+        module = imp.resolved_module or imp.module
+        aliases[imp.name] = module if imp.module == original else f"{module}.{original}"
 
     def resolve(written: str) -> str:
         head, _, rest = written.partition(".")

--- a/codeanalyzer/neo4j/project.py
+++ b/codeanalyzer/neo4j/project.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from codeanalyzer.neo4j.schema import SCHEMA_VERSION
 from codeanalyzer.neo4j.rows import GraphRows, NodeRef, Props, RowBuilder, prune
@@ -87,7 +87,8 @@ def project(app: PyApplication, app_name: str, sig_to_id: dict,
     for file_key, mod in app.symbol_table.items():
         mod_ref = b.node(["PyModule"], "id", mod.id, _module_props(mod, file_key))
         b.edge("PY_HAS_MODULE", app_ref, mod_ref)
-        _project_module_body(b, file_key, mod_ref, mod, externals, sig_to_id, module_id_by_key)
+        _project_module_body(b, file_key, mod_ref, mod, externals, sig_to_id, module_id_by_key,
+                             application_id(app_name))
 
     # The aggregated :PY_CALLS twin.
     for e in app.call_graph:
@@ -449,6 +450,45 @@ def _symbol_ref(signature: str, externals: dict, sig_to_id: dict) -> NodeRef:
     return NodeRef("PySymbol", "signature", signature)
 
 
+def _base_ref_resolver(
+    b: RowBuilder, mod: PyModule, externals: dict, sig_to_id: dict, app_can_id: str,
+) -> Callable[[str], NodeRef]:
+    """Per-module: the written base spelling → the NodeRef PY_EXTENDS lands on (#178).
+
+    ``base_classes`` stores the spelling as written (``Base``, ``views.View``),
+    while ``sig_to_id`` is keyed by signature (``pkg.mod.Base``), so the two never
+    met and every PY_EXTENDS row was dropped as dangling. Resolution order: a class
+    declared in this module (bare name or ``Outer.Inner`` path) → its can:// id; a
+    name the module's import table maps (same resolver the entrypoint pass uses)
+    that is a declared class elsewhere → its can:// id; otherwise an ``@external``
+    ghost with the id shape ``_home_external_symbols`` uses, so a call to the same
+    symbol MERGEs onto the same node."""
+    from codeanalyzer.entrypoints.pipeline import _base_resolver
+
+    local: Dict[str, str] = {}
+
+    def index(cl: PyClass, path: str) -> None:
+        local.setdefault(cl.name, cl.signature)
+        local[path] = cl.signature
+        for ic in (cl.types or {}).values():
+            index(ic, f"{path}.{ic.name}")
+
+    for cl in (mod.types or {}).values():
+        index(cl, cl.name)
+    resolve = _base_resolver(mod)
+
+    def base_ref(written: str) -> NodeRef:
+        sig = local.get(written) or resolve(written)
+        can_id = sig_to_id.get(sig)
+        if can_id is not None:
+            return _sym(can_id)
+        module, name = sig.rsplit(".", 1) if "." in sig else (None, sig)
+        ext_id = f"{app_can_id}/@external/{module}/{name}" if module else f"{app_can_id}/@external/{name}"
+        return b.node(["PySymbol", "PyExternal"], "id", ext_id, prune({"name": name, "module": module}))
+
+    return base_ref
+
+
 def _call_endpoint(
     b: RowBuilder, signature: str, externals: dict, sig_to_id: dict
 ) -> NodeRef:
@@ -496,14 +536,15 @@ def _call_endpoint(
 
 def _project_module_body(
     b: RowBuilder, file_key: str, mod_ref: NodeRef, mod: PyModule,
-    externals: dict, sig_to_id: dict, module_id_by_key: dict,
+    externals: dict, sig_to_id: dict, module_id_by_key: dict, app_can_id: str,
 ) -> None:
+    base_ref = _base_ref_resolver(b, mod, externals, sig_to_id, app_can_id)
     for fn in (mod.functions or {}).values():
         _project_callable(b, file_key, mod_ref, "PY_DECLARES", fn, externals, sig_to_id,
-                          mod.source)
+                          mod.source, base_ref)
     for cl in (mod.types or {}).values():
         _project_class(b, file_key, mod_ref, "PY_DECLARES", cl, externals, sig_to_id,
-                       mod.source)
+                       mod.source, base_ref)
     for v in mod.variables or []:
         _project_variable(b, file_key, mod_ref, file_key, v)
     _project_imports(b, mod_ref, mod, module_id_by_key)
@@ -571,7 +612,7 @@ def _project_imports(b: RowBuilder, mod_ref: NodeRef, mod: PyModule,
 
 def _project_class(
     b: RowBuilder, file_key: str, parent: NodeRef, parent_rel: str, cl: PyClass,
-    externals: dict, sig_to_id: dict, source: str,
+    externals: dict, sig_to_id: dict, source: str, base_ref: Callable[[str], NodeRef],
 ) -> None:
     ref = b.node(
         ["PySymbol", "PyClass"], "id", cl.id, _class_props(cl, file_key, source)
@@ -583,20 +624,21 @@ def _project_class(
 
     for base in cl.base_classes or []:
         if base:
-            b.edge_to_symbol("PY_EXTENDS", ref, _symbol_ref(base, externals, sig_to_id))
+            b.edge_to_symbol("PY_EXTENDS", ref, base_ref(base))
 
     for m in (cl.callables or {}).values():
         _project_callable(b, file_key, ref, "PY_HAS_METHOD", m, externals, sig_to_id,
-                          source)
+                          source, base_ref)
     for a in (cl.attributes or {}).values():
         _project_attribute(b, file_key, ref, cl.signature, a)
     for ic in (cl.types or {}).values():
-        _project_class(b, file_key, ref, "PY_DECLARES", ic, externals, sig_to_id, source)
+        _project_class(b, file_key, ref, "PY_DECLARES", ic, externals, sig_to_id, source,
+                       base_ref)
 
 
 def _project_callable(
     b: RowBuilder, file_key: str, owner: NodeRef, owner_rel: str, c: PyCallable,
-    externals: dict, sig_to_id: dict, source: str,
+    externals: dict, sig_to_id: dict, source: str, base_ref: Callable[[str], NodeRef],
 ) -> None:
     ref = b.node(
         ["PySymbol", "PyCallable"],
@@ -613,9 +655,10 @@ def _project_callable(
         _project_variable(b, file_key, ref, c.signature, v)
     for ic in (c.callables or {}).values():
         _project_callable(b, file_key, ref, "PY_DECLARES", ic, externals, sig_to_id,
-                          source)
+                          source, base_ref)
     for cl in (c.types or {}).values():
-        _project_class(b, file_key, ref, "PY_DECLARES", cl, externals, sig_to_id, source)
+        _project_class(b, file_key, ref, "PY_DECLARES", cl, externals, sig_to_id, source,
+                       base_ref)
 
 
 def _project_attribute(

--- a/docs/skills/analyzing-canpy-graphs/references/vocabulary.md
+++ b/docs/skills/analyzing-canpy-graphs/references/vocabulary.md
@@ -21,6 +21,11 @@ In `analysis.json` the same value is `body[<local>].id` on every body node, and
 `parameters[i].id` is `<callable-id>@formal_in:<i>` — so a JSON-side node and its
 `:PyBodyNode` join on one string without recomposing the id.
 
+`PyClass.code` / `PyCallable.code` is exactly `module.source[span.bytes]`, one contiguous
+slice starting at the `class`/`def` token. For a nested declaration the first line therefore
+carries no indentation while continuation lines keep theirs; strip `span.start[1]` columns from
+those lines to dedent.
+
 `PyBodyNode.kind`: `entry`, `exit`, `statement`, `branch`, `loop`, `return`,
 `raise`, `handler`, `call`, `formal_in`, `formal_out`, `actual_in`, `actual_out`.
 

--- a/test/sample_graph_app.py
+++ b/test/sample_graph_app.py
@@ -109,16 +109,6 @@ def read_config():
 '''
 
 
-def _qualify_base_classes(module) -> None:
-    """Resolve each class's bare base-class names to their in-module signatures
-    (``BaseService`` → ``service.BaseService``), mirroring what a semantic
-    resolution pass does, so the Neo4j PY_EXTENDS edge lands on the declared base
-    class's ``can://`` id rather than dangling on an unresolved bare name."""
-    name_to_sig = {cls.name: cls.signature for cls in (module.types or {}).values()}
-    for cls in (module.types or {}).values():
-        cls.base_classes = [name_to_sig.get(b, b) for b in (cls.base_classes or [])]
-
-
 def make_sample_app() -> Tuple[PyApplication, Dict[str, str]]:
     """Build the v2 sample application with its level-3 CPG overlay and level-4
     interprocedural delta emitted.
@@ -130,7 +120,6 @@ def make_sample_app() -> Tuple[PyApplication, Dict[str, str]]:
     source_file.write_text(_SOURCE, encoding="utf-8")
 
     module = SymbolTableBuilder(workdir, None).build_pymodule_from_file(source_file)
-    _qualify_base_classes(module)
     app = PyApplication(symbol_table={"service.py": module})
 
     # Two independent builds of this fixture must project byte-identical rows (the

--- a/test/test_v2_two_projection_agreement.py
+++ b/test/test_v2_two_projection_agreement.py
@@ -289,3 +289,37 @@ def test_l4_param_vertex_ids_and_parameter_ids_agree(tmp_path):
             vertex = fn.body[f"@formal_in:{i}"]
             assert vertex.id == p.id
             assert vertex.of == p.name
+
+
+# ----------------------------------------------------------------------------------------------
+# #178: PY_EXTENDS resolves the written base to the declared class's can:// id, or to an
+# @external ghost — never to a bare spelling nothing emits (which RowBuilder drops).
+# ----------------------------------------------------------------------------------------------
+
+_EXTENDS_FIXTURE = (
+    "from lib.core import Thing\n"
+    "import lib.views as views\n"
+    "class Base:\n    pass\n"
+    "class Child(Base):\n    pass\n"
+    "class Ext(Thing):\n    pass\n"
+    "class Dotted(views.View):\n    pass\n"
+)
+
+
+def test_py_extends_targets_declared_base_by_can_id_and_external_by_ghost(tmp_path):
+    f = tmp_path / "m.py"
+    f.write_text(_EXTENDS_FIXTURE, encoding="utf-8")
+    mod = SymbolTableBuilder(tmp_path, None).build_pymodule_from_file(f)
+    app = PyApplication(symbol_table={"m.py": mod})
+    sig_to_id = assign_ids(app, "app")
+    by_name = {c.name: c for c in mod.types.values()}
+    assert by_name["Child"].base_classes == ["Base"], "precondition: written spelling"
+
+    rows = project(app, "app", sig_to_id)
+    ext = {(e.from_ref.value, e.to_ref.value) for e in rows.edges if e.type == "PY_EXTENDS"}
+    assert (by_name["Child"].id, by_name["Base"].id) in ext
+    assert (by_name["Ext"].id, "can://python/app/@external/lib.core/Thing") in ext
+    assert (by_name["Dotted"].id, "can://python/app/@external/lib.views/View") in ext
+    assert len(ext) == 3
+    ghosts = {n.value for n in rows.nodes if "PyExternal" in n.labels}
+    assert "can://python/app/@external/lib.core/Thing" in ghosts


### PR DESCRIPTION
Closes #178.

The class projector handed the written base spelling (`Base`, `views.View`) to a lookup keyed by signature (`pkg.mod.Base`), so every inheritance edge targeted a key nothing emits and `RowBuilder.finish()` dropped it as dangling. No graph since 2.0.0 carried a `PY_EXTENDS` edge; the suite stayed green only because `test/sample_graph_app.py` pre-resolved its bases by hand. That pre-resolution is removed.

Bases now resolve per module: a class declared in the module (bare name or `Outer.Inner`) or reachable through the module's import table lands on its `can://` id; anything else lands on an `@external` ghost with the id shape call targets use, so a call to the same symbol merges onto one node. The shared base resolver now prefers `resolved_module`, which also fixes entrypoint base matching through relative imports.

Also closes the other two #178 items as docs: `reaching-defs` documented as the third DDG `prov` value (L4 port wiring, shared with typescript); `code` documented as the exact `span.bytes` slice, first line unindented.

Gates: `pytest` 472 passed, 8 skipped. New test: in-module base → `can://` id, imported base → `@external/lib.core/Thing`, dotted alias → `@external/lib.views/View`.
