### PR TITLE
fix(neo4j)!: scope every destructive statement on the can:// id prefix; retire _module

### DIFF
--- a/.claude/SCHEMA_DECISIONS.md
+++ b/.claude/SCHEMA_DECISIONS.md
@@ -440,3 +440,37 @@ Spec: `codellm-devkit/.github` → `docs/design/specs/2026-09-05-body-node-id-in
   class attributes/variables (signature-minted Neo4j ids, being redone under
   #173) do not get one. `schema_version` stays `2.0.0`; graph contract
   unchanged.
+
+## 2026-09-05 — Destructive Neo4j statements scope on the `can://` prefix; `_module` retires (issue #173, epic .github#50)
+
+Spec: `codellm-devkit/.github` → `docs/design/specs/2026-09-02-prune-scope-on-can-id-prefix.md`.
+Reference implementation: codeanalyzer-java#220.
+
+- **Scope is identity, not a property.** Every delete — the per-module purge,
+  the full-run orphan prune, the snapshot wipe — matches `x.id = <id> OR x.id
+  STARTS WITH <id> + '/'`. The id already carries language, application and
+  file, so a prefix match is containment and separates two python applications
+  sharing a module path, which no label anchor can (identical labels). The
+  separator is mandatory (`rows.descendant_prefix`); an empty application id is
+  refused (`rows.application_prefix`) rather than becoming `STARTS WITH ''`.
+- **`_module` leaves the graph, not the writer.** `RowBuilder.node` lifts it off
+  the props into `NodeRow.module`, so no projector call site changed and the
+  incremental diff still groups by module. The module id for the purge comes
+  from the module's own row — never by splitting a declaration's id, because a
+  file key may itself contain `/`.
+- **`PyCanNode` is an index anchor only.** Neo4j property indexes are
+  label-scoped; without a label the prefix predicate scans the store. `STARTS
+  WITH` seeks a range index, `CONTAINS`/`ENDS WITH` do not. Per-language
+  marker (not a shared `CanNode`) so three analyzers do not contend on one
+  index and a wrong prefix still costs one language at most. Add a shared
+  label alongside only when a polyglot consumer asks for it.
+- **Attribute and variable ids are `can://`.** `<class-id>/<name>` and
+  `<owner-id>/<name>@<line>`. The signature-minted ids they replace had no
+  application segment and MERGEd across applications; they also fell outside
+  every prefix, so the purge would have stopped reaching them. Module-level
+  variables hang under `<module-id>/` so the module's own prefix reaches them.
+- **No bare-signature ids remain.** `_call_endpoint`'s last-resort ghost now
+  mints `<app>/@external/<module>/<name>` (the `_home_external_symbols` shape),
+  so java's "legacy ids cannot be prefix-scoped" case has no python analogue.
+- Graph contract `2.0.0 → 3.0.0` (a property removed). `analysis.json` is
+  untouched; `_module` never appeared there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `from odoo import http` plus `@http.route` matches `odoo.http.route` with
   odoo not importable in the analysis environment, which is every `--no-venv`
   run.
+- `:PyCanNode` marker label on every node keyed by a `can://python/` id, with a
+  range index on `id`. It is the anchor the prefix predicates seek on; scope
+  comes from the prefix, not the label. `:PyExternal` nodes carry it too, so
+  external→application `PY_CALLS` edges sit inside the application scope
+  (#179).
+
+### Changed
+
+- **BREAKING (graph contract 3.0.0):** every destructive Neo4j statement is
+  scoped on the `can://` id prefix, and the internal `_module` property retires
+  from every node, from the catalog and from its six per-label indexes (#173,
+  epic codellm-devkit/.github#50). The per-module purge matches the module by
+  id and its subtree by `id STARTS WITH <module-id> + '/'`; the full-run orphan
+  prune and the snapshot wipe match `can://python/<app>/`. Two python
+  applications sharing a module path no longer delete each other's nodes; an
+  empty application id is refused instead of matching the whole store.
+  Migration: a consumer that filtered on `x._module` filters on
+  `x.id STARTS WITH 'can://python/<app>/<file>/'` instead.
+- **BREAKING:** `:PyAttribute` and `:PyVariable` ids are minted from the owner's
+  `can://` id — `<class-id>/<name>` and `<owner-id>/<name>@<line>` — instead of
+  from its signature. The old ids (`service.Service.name`) carried no
+  application segment, so two applications MERGEd onto one node.
+- A call target nobody homed now lands on an `@external` ghost under the
+  application prefix (`can://python/<app>/@external/<module>/<name>`), never
+  on a bare-signature id, so every id-keyed node is a `can://` node.
 
 ### Fixed
 
@@ -44,6 +69,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   all, so it read `{}` on every run; it now counts, per written spelling, the
   decorators and base classes that neither Jedi nor the import table could
   name.
+- The Bolt writer's `content_hash` diff compared the module row's `can://` id
+  against a file key and never matched, so every module counted as changed on
+  every push. It now reads the module row directly, and keys the database side
+  by module id under the application prefix: keyed by file key it was
+  application-blind, so a second application whose module shared the path and
+  the hash looked "unchanged" and was never written.
+
 
 ## [1.4.0] - 2026-09-02
 

--- a/codeanalyzer/neo4j/bolt.py
+++ b/codeanalyzer/neo4j/bolt.py
@@ -37,13 +37,16 @@ opt-in under the same flag that already forces a clean analysis rebuild.
 
 Nodes are MERGE-upserted, never blindly deleted, so a declaration another
 (unchanged) module still references survives and its incoming edges stay valid.
-``:PyExternal`` / ``:PyPackage`` / ``:PyDecorator`` are shared (no ``_module``) and are
+``:PyExternal`` / ``:PyPackage`` / ``:PyDecorator`` have no owning module and are
 MERGE-only.
 
-Every ``_module`` match is anchored on the python-owned labels
-(``schema.MODULE_OWNED_PATTERN``). ``_module`` is a shared convention, not a python-private
-one -- codeanalyzer-java and codeanalyzer-typescript set it on their nodes too -- so an
-unlabelled match reaches a sibling analyzer's graph in a shared database (#171).
+**Every destructive statement is scoped on the ``can://`` id prefix** (#173). The id is a
+path — ``can://python/<app>/<file>/...`` — so ``id = <module-id> OR id STARTS WITH
+<module-id> + '/'`` is containment, and it is one language, one application and one
+module at once. That is what neither a label anchor nor the retired ``_module`` property
+could give: two python applications sharing ``src/foo.py`` carry identical labels and an
+identical file key, and only the id tells them apart. ``:PyCanNode`` anchors the predicate
+so it seeks an index instead of scanning the store; it carries no safety claim.
 
 The ``neo4j`` driver is imported lazily so it stays an optional dependency and
 off the default (json) output path entirely.
@@ -53,15 +56,33 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from codeanalyzer.neo4j.rows import EdgeRow, GraphRows, NodeRow, chunk
-from codeanalyzer.neo4j.schema import CONSTRAINTS, INDEXES, MODULE_OWNED_PATTERN
+from codeanalyzer.neo4j.rows import (
+    CAN_NODE, EdgeRow, GraphRows, NodeRow, application_prefix, chunk, descendant_prefix,
+)
+from codeanalyzer.neo4j.schema import CONSTRAINTS, INDEXES
 from codeanalyzer.utils import logger
 
-DESCENDANTS = (
-    "[:PY_DECLARES|PY_HAS_METHOD|PY_HAS_ATTRIBUTE|PY_DECLARES_VAR"
-    "|PY_HAS_CALLSITE|PY_HAS_BODY_NODE*1..]"
-)
 BATCH = 1000
+
+# The per-module purge (#173): the module by equality, its subtree by prefix. Anchored
+# on :PyCanNode only so the predicate can seek (see ``rows.CAN_NODE``).
+PURGE_MODULE_EDGES = (
+    f"MATCH (x:{CAN_NODE}) WHERE x.id = $mid OR x.id STARTS WITH $pre "
+    "MATCH (x)-[r]->() DELETE r"
+)
+PURGE_VANISHED_NODES = (
+    f"MATCH (x:{CAN_NODE}) WHERE (x.id = $mid OR x.id STARTS WITH $pre) "
+    "AND NOT x.id IN $keys DETACH DELETE x"
+)
+# The orphan prune: modules inside this application's prefix that the run no longer
+# emits, and everything under each. Batched — deleting a large application in one
+# transaction exhausts dbms.memory.transaction.total.max (typescript#116).
+PRUNE_VANISHED_MODULES = (
+    f"MATCH (m:PyModule:{CAN_NODE}) WHERE m.id STARTS WITH $app AND NOT m.id IN $present "
+    f"CALL {{ WITH m MATCH (x:{CAN_NODE}) WHERE x.id = m.id OR x.id STARTS WITH m.id + '/' "
+    "DETACH DELETE x } IN TRANSACTIONS OF 1000 ROWS "
+    "RETURN count(*) AS pruned"
+)
 
 
 @dataclass
@@ -93,35 +114,44 @@ def bolt_writer(rows: GraphRows, cfg: BoltConfig, full_run: bool, eager: bool = 
             for stmt in [*CONSTRAINTS, *INDEXES]:
                 s.run(stmt)
 
-        # The application anchor (a shared node) — used to scope the orphan prune
-        # so it never touches modules belonging to a different :PyApplication.
+        # The application anchor. Every destructive statement below is scoped to
+        # ``can://python/<app>/``; an empty application id is refused up front rather
+        # than becoming ``STARTS WITH ''`` (every node in the database).
         app_name = next(
             (n.value for n in rows.nodes if n.labels and n.labels[0] == "PyApplication"),
             None,
         )
+        app_prefix = application_prefix(app_name)
 
-        # Partition nodes by owning module; shared nodes have no _module.
+        # Partition nodes by owning module (an in-memory field, never emitted, #173);
+        # shared nodes have none.
         by_module: Dict[str, List[NodeRow]] = {}
         shared: List[NodeRow] = []
         module_of: Dict[str, str] = {}  # node value → owning module
         for n in rows.nodes:
-            m = n.props.get("_module")
-            if isinstance(m, str):
-                by_module.setdefault(m, []).append(n)
-                module_of[n.value] = m
+            if n.module is not None:
+                by_module.setdefault(n.module, []).append(n)
+                module_of[n.value] = n.module
             else:
                 shared.append(n)
 
-        # 2. diff content_hash.
+        # 2. diff content_hash, keyed by module id inside this application's prefix.
+        # Keyed by file key it was application-blind: a second application whose
+        # module shares the path and the hash looked "unchanged" and was never written.
         db_hash: Dict[str, Optional[str]] = {}
         with session() as s:
-            res = s.run("MATCH (m:PyModule) RETURN m.file_key AS k, m.content_hash AS h")
+            res = s.run(
+                f"MATCH (m:PyModule:{CAN_NODE}) WHERE m.id STARTS WITH $app "
+                "RETURN m.id AS k, m.content_hash AS h",
+                app=app_prefix,
+            )
             for rec in res:
                 db_hash[rec["k"]] = rec["h"]
         changed = set()
         for m, nodes in by_module.items():
-            row_hash = _hash_of(nodes, m)
-            if m not in db_hash or row_hash is None or row_hash != db_hash.get(m):
+            mid = _module_id_of(nodes)
+            row_hash = _hash_of(nodes)
+            if mid not in db_hash or row_hash is None or row_hash != db_hash.get(mid):
                 changed.add(m)
         logger.info(
             f"neo4j(bolt): {len(by_module)} modules ({len(changed)} changed), "
@@ -139,23 +169,19 @@ def bolt_writer(rows: GraphRows, cfg: BoltConfig, full_run: bool, eager: bool = 
             if not eager:
                 _upsert_nodes(session, neo4j, nodes)
                 continue
+            # The module id comes from the module's own row, never by splitting a
+            # declaration's id: a file key may itself contain '/'.
+            module_id = _module_id_of(nodes)
+            if module_id is None or not module_id.startswith(app_prefix):
+                raise ValueError(
+                    f"neo4j: module {m!r} has no can:// id under {app_prefix!r}; "
+                    "refusing to purge"
+                )
             with session() as s:
-                def _purge(tx, module=m, node_keys=keys):
-                    # Anchored on python-owned labels: `_module` is also set by the java
-                    # and typescript analyzers, so an unlabelled match would delete a
-                    # sibling's nodes wherever a file key collides (#171).
-                    tx.run(
-                        f"MATCH (x:{MODULE_OWNED_PATTERN}) WHERE x._module = $m "
-                        "MATCH (x)-[r]->() DELETE r",
-                        m=module,
-                    )
-                    tx.run(
-                        f"MATCH (x:{MODULE_OWNED_PATTERN}) WHERE x._module = $m "
-                        "AND NOT coalesce(x.signature, x.id, x.file_key) IN $keys "
-                        "DETACH DELETE x",
-                        m=module,
-                        keys=node_keys,
-                    )
+                def _purge(tx, mid=module_id, node_keys=keys):
+                    params = {"mid": mid, "pre": descendant_prefix(mid)}
+                    tx.run(PURGE_MODULE_EDGES, **params)
+                    tx.run(PURGE_VANISHED_NODES, keys=node_keys, **params)
 
                 s.execute_write(_purge)
             _upsert_nodes(session, neo4j, nodes)
@@ -169,19 +195,13 @@ def bolt_writer(rows: GraphRows, cfg: BoltConfig, full_run: bool, eager: bool = 
         _upsert_edges(session, neo4j, edges)
 
         # 6. orphan prune — only safe on a full run (a targeted run can't tell deleted from untargeted).
-        # Scope to THIS application's anchor so a full run for application B never
-        # deletes application A's modules from a shared database.
-        if full_run and eager and app_name is not None:
-            present = list(by_module.keys())
+        # Scoped to ``can://python/<app>/`` so a full run for application B never deletes
+        # application A's modules from a shared database — even when both are python and
+        # share a module path.
+        if full_run and eager:
+            present = [mid for mid in (_module_id_of(ns) for ns in by_module.values()) if mid]
             with session() as s:
-                res = s.run(
-                    "MATCH (:PyApplication {name: $app})-[:PY_HAS_MODULE]->(m:PyModule) "
-                    "WHERE NOT m.file_key IN $present "
-                    f"OPTIONAL MATCH (m)-{DESCENDANTS}->(x) DETACH DELETE x, m "
-                    "RETURN count(m) AS pruned",
-                    app=app_name,
-                    present=present,
-                )
+                res = s.run(PRUNE_VANISHED_MODULES, app=app_prefix, present=present)
                 pruned = res.single()
                 pruned_count = pruned["pruned"] if pruned else 0
                 logger.info(f"neo4j(bolt): pruned {pruned_count} vanished module(s)")
@@ -263,12 +283,19 @@ def _upsert_edges(session, neo4j, edges: List[EdgeRow]) -> None:
 # ----------------------------------------------------------------------------------------------
 
 
-def _hash_of(nodes: List[NodeRow], file_key: str) -> Optional[str]:
-    for n in nodes:
-        if n.labels[0] == "PyModule" and n.value == file_key:
-            h = n.props.get("content_hash")
-            return h if isinstance(h, str) else None
-    return None
+def _module_row(nodes: List[NodeRow]) -> Optional[NodeRow]:
+    return next((n for n in nodes if n.labels[0] == "PyModule"), None)
+
+
+def _module_id_of(nodes: List[NodeRow]) -> Optional[str]:
+    row = _module_row(nodes)
+    return row.value if row is not None else None
+
+
+def _hash_of(nodes: List[NodeRow]) -> Optional[str]:
+    row = _module_row(nodes)
+    h = row.props.get("content_hash") if row is not None else None
+    return h if isinstance(h, str) else None
 
 
 def _to_params(props, neo4j) -> dict:

--- a/codeanalyzer/neo4j/cypher.py
+++ b/codeanalyzer/neo4j/cypher.py
@@ -28,9 +28,11 @@ from __future__ import annotations
 from typing import Dict, List
 
 from codeanalyzer.neo4j.rows import (
+    CAN_NODE,
     EdgeRow,
     GraphRows,
     NodeRow,
+    application_prefix,
     chunk,
     cypher_map,
     cypher_value,
@@ -66,13 +68,17 @@ def render_cypher(rows: GraphRows, app_name: str) -> str:
 
 
 def _wipe(app_name: str) -> str:
+    """Everything under ``can://python/<app>/`` plus the application anchor (#173).
+    Scoped by id prefix, so it is one language and one application by construction —
+    a second python app sharing a module path, a sibling analyzer's graph, and the
+    cross-language :Artifact / :Package nodes are all outside it."""
+    prefix = cypher_value(application_prefix(app_name))
     name = cypher_value(app_name)
     return "\n".join(
         [
-            f"MATCH (a:PyApplication {{name: {name}}})",
-            "OPTIONAL MATCH (a)-[:PY_HAS_MODULE]->(m:PyModule)",
-            "OPTIONAL MATCH (m)-[:PY_DECLARES|PY_HAS_METHOD|PY_HAS_ATTRIBUTE|PY_DECLARES_VAR|PY_HAS_CALLSITE*1..]->(x)",
-            "DETACH DELETE x, m, a;",
+            f"MATCH (x:{CAN_NODE}) WHERE x.id STARTS WITH {prefix}",
+            "CALL { WITH x DETACH DELETE x } IN TRANSACTIONS OF 1000 ROWS;",
+            f"MATCH (a:PyApplication {{name: {name}}}) DETACH DELETE a;",
         ]
     )
 

--- a/codeanalyzer/neo4j/project.py
+++ b/codeanalyzer/neo4j/project.py
@@ -27,7 +27,8 @@ Modelling decisions (mirror of the TypeScript backend):
   - call-graph endpoints absent from the symbol table become ``:PyExternal`` ghost
     nodes, so RPC / third-party / framework edges are preserved (matching the
     analyzer's own ghost-node behaviour).
-  - every project-owned node carries an internal ``_module`` provenance prop, so
+  - every project-owned node names its owning module (``_module`` in the props it
+    hands RowBuilder, lifted to ``NodeRow.module`` and never emitted, #173), so
     the incremental writer can delete exactly what a re-analyzed module emitted.
 """
 from __future__ import annotations
@@ -98,16 +99,17 @@ def project(app: PyApplication, app_name: str, sig_to_id: dict,
                              application_id(app_name))
 
     # The aggregated :PY_CALLS twin.
+    app_can_id = application_id(app_name)
     for e in app.call_graph:
-        src = _call_endpoint(b, e.src, externals, sig_to_id)
-        tgt = _call_endpoint(b, e.dst, externals, sig_to_id)
+        src = _call_endpoint(b, e.src, externals, sig_to_id, app_can_id)
+        tgt = _call_endpoint(b, e.dst, externals, sig_to_id, app_can_id)
         b.edge(
             "PY_CALLS", src, tgt, _call_edge_props(e.weight, list(e.prov or []))
         )
 
     # Level-3 CPG overlay: each callable's v2 body/cfg/cdg/ddg. Idempotent under
     # MERGE — a no-op when no callable carries L3 fields (levels 1/2).
-    _project_program_graphs(b, app, externals, sig_to_id)
+    _project_program_graphs(b, app, externals, sig_to_id, app_can_id)
 
     # Neutral artifact/dependency subgraph (Task 6). L1 data — always present,
     # full-depth-always regardless of -a.
@@ -117,7 +119,7 @@ def project(app: PyApplication, app_name: str, sig_to_id: dict,
     # _project_program_graphs above) into the config-key subgraph
     # (ConfigKey from _project_artifacts above), plus first-class unresolved
     # reads.
-    _project_config_uses(b, app, app_ref, externals, sig_to_id)
+    _project_config_uses(b, app, app_ref, externals, sig_to_id, app_can_id)
 
     return b.finish()
 
@@ -144,7 +146,7 @@ def _body_ref(callable_id: str, local_key: str) -> NodeRef:
 
 
 def _project_program_graphs(
-    b: RowBuilder, app: PyApplication, externals: dict, sig_to_id: dict
+    b: RowBuilder, app: PyApplication, externals: dict, sig_to_id: dict, app_can_id: str,
 ) -> None:
     """Level-3 CPG overlay, projected off each callable's v2 ``body``/``cfg``/
     ``cdg``/``ddg`` (populated by ``emit_l3_body`` at ``-a 3``; empty otherwise).
@@ -213,7 +215,7 @@ def _project_program_graphs(
                     b.edge(
                         "PY_RESOLVES_TO",
                         ref,
-                        _call_endpoint(b, node.callee, externals, sig_to_id),
+                        _call_endpoint(b, node.callee, externals, sig_to_id, app_can_id),
                     )
             for e in c.cfg or []:
                 # kind-discriminated: a conditional's true/false pair between one
@@ -403,6 +405,7 @@ def _project_artifacts(b: RowBuilder, app: PyApplication, app_name: str, app_ref
 
 def _project_config_uses(
     b: RowBuilder, app: PyApplication, app_ref: NodeRef, externals: dict, sig_to_id: dict,
+    app_can_id: str,
 ) -> None:
     """config_use (#162): PY_USES_CONFIG (`app.config_uses`) and
     PY_READS_CONFIG_UNRESOLVED (`app.config_reads_unresolved`).
@@ -432,7 +435,7 @@ def _project_config_uses(
             prune({"prov": list(e.prov) if e.prov else None}),
         )
     for r in app.config_reads_unresolved:
-        ghost_ref = _call_endpoint(b, r.callee, externals, sig_to_id)
+        ghost_ref = _call_endpoint(b, r.callee, externals, sig_to_id, app_can_id)
         b.edge(
             "PY_READS_CONFIG_UNRESOLVED",
             app_ref,
@@ -489,15 +492,22 @@ def _base_ref_resolver(
         can_id = sig_to_id.get(sig)
         if can_id is not None:
             return _sym(can_id)
-        module, name = sig.rsplit(".", 1) if "." in sig else (None, sig)
-        ext_id = f"{app_can_id}/@external/{module}/{name}" if module else f"{app_can_id}/@external/{name}"
-        return b.node(["PySymbol", "PyExternal"], "id", ext_id, prune({"name": name, "module": module}))
+        return _external_ghost(b, app_can_id, sig)
 
     return base_ref
 
 
+def _external_ghost(b: RowBuilder, app_can_id: str, signature: str) -> NodeRef:
+    """A :PyExternal ghost for a dotted signature nobody homed, with the id shape
+    ``_home_external_symbols`` uses — ``<app>/@external/<module>/<name>`` — so it
+    sits inside the application prefix (#173) and MERGEs with a homed twin."""
+    module, name = signature.rsplit(".", 1) if "." in signature else (None, signature)
+    ext_id = f"{app_can_id}/@external/{module}/{name}" if module else f"{app_can_id}/@external/{name}"
+    return b.node(["PySymbol", "PyExternal"], "id", ext_id, prune({"name": name, "module": module}))
+
+
 def _call_endpoint(
-    b: RowBuilder, signature: str, externals: dict, sig_to_id: dict
+    b: RowBuilder, signature: str, externals: dict, sig_to_id: dict, app_can_id: str,
 ) -> NodeRef:
     """A call-graph endpoint: a declared callable already emitted (keyed by its
     canonical ``can://`` id, resolved through ``sig_to_id``), or an external symbol
@@ -527,13 +537,7 @@ def _call_endpoint(
             ext.id or signature,
             prune({"name": ext.name, "module": ext.module}),
         )
-    name = signature.rsplit(".", 1)[-1] if "." in signature else signature
-    return b.node(
-        ["PySymbol", "PyExternal"],
-        "id",
-        signature,
-        prune({"name": name}),
-    )
+    return _external_ghost(b, app_can_id, signature)
 
 
 # ----------------------------------------------------------------------------------------------
@@ -553,7 +557,7 @@ def _project_module_body(
         _project_class(b, file_key, mod_ref, "PY_DECLARES", cl, externals, sig_to_id,
                        mod.source, base_ref)
     for v in mod.variables or []:
-        _project_variable(b, file_key, mod_ref, file_key, v)
+        _project_variable(b, file_key, mod_ref, v)
     _project_imports(b, mod_ref, mod, module_id_by_key)
 
 
@@ -637,7 +641,7 @@ def _project_class(
         _project_callable(b, file_key, ref, "PY_HAS_METHOD", m, externals, sig_to_id,
                           source, base_ref)
     for a in (cl.attributes or {}).values():
-        _project_attribute(b, file_key, ref, cl.signature, a)
+        _project_attribute(b, file_key, ref, a)
     for ic in (cl.types or {}).values():
         _project_class(b, file_key, ref, "PY_DECLARES", ic, externals, sig_to_id, source,
                        base_ref)
@@ -659,7 +663,7 @@ def _project_callable(
         _project_decorator(b, ref, d)
 
     for v in c.local_variables or []:
-        _project_variable(b, file_key, ref, c.signature, v)
+        _project_variable(b, file_key, ref, v)
     for ic in (c.callables or {}).values():
         _project_callable(b, file_key, ref, "PY_DECLARES", ic, externals, sig_to_id,
                           source, base_ref)
@@ -669,9 +673,12 @@ def _project_callable(
 
 
 def _project_attribute(
-    b: RowBuilder, file_key: str, owner: NodeRef, owner_sig: str, a: PyClassAttribute
+    b: RowBuilder, file_key: str, owner: NodeRef, a: PyClassAttribute
 ) -> None:
-    attr_id = f"{owner_sig}.{a.name}"
+    # ``<class can:// id>/<name>`` (#173): minted from the owner's id so it carries
+    # the application segment. The signature-minted ``service.Service.name`` it
+    # replaced was identical across applications, so two apps MERGEd onto one node.
+    attr_id = f"{owner.value}/{a.name}"
     ref = b.node(["PyAttribute"], "id", attr_id, _attribute_props(a, attr_id, file_key))
     b.edge("PY_HAS_ATTRIBUTE", owner, ref)
 
@@ -680,10 +687,12 @@ def _project_variable(
     b: RowBuilder,
     file_key: str,
     owner: NodeRef,
-    owner_id: str,
     v: PyVariableDeclaration,
 ) -> None:
-    var_id = f"{owner_id}#{v.name}@{v.start_line}"
+    # ``<owner can:// id>/<name>@<line>`` (#173) — the owner is the module or the
+    # callable, so a module-level variable sits under ``<module-id>/`` like every
+    # other declaration and the module's prefix purge reaches it.
+    var_id = f"{owner.value}/{v.name}@{v.start_line}"
     ref = b.node(["PyVariable"], "id", var_id, _variable_props(v, var_id, file_key))
     b.edge("PY_DECLARES_VAR", owner, ref)
 

--- a/codeanalyzer/neo4j/rows.py
+++ b/codeanalyzer/neo4j/rows.py
@@ -50,6 +50,35 @@ class NodeRow:
     key_prop: str
     value: str
     props: Props
+    # The owning module's file key, for the incremental writer's per-module diff.
+    # In memory only (#173): it used to be emitted as ``_module`` and every
+    # destructive statement matched on it, which is application-blind. Scope now
+    # comes from the ``can://`` id prefix; this field only groups rows.
+    module: Optional[str] = None
+
+
+# The marker label on every node keyed by a ``can://python/`` id (#173). It is an
+# INDEX ANCHOR, nothing more: Neo4j property indexes are label-scoped, so the
+# prefix predicate ``id STARTS WITH $p`` needs a label to seek on. Safety comes
+# from the prefix, which carries language, application and module.
+CAN_NODE = "PyCanNode"
+_PY_CAN_PREFIX = "can://python/"
+
+
+def descendant_prefix(can_id: str) -> str:
+    """The prefix that matches a node's descendants and nothing else. The separator
+    is the point: ``can://python/app/src/foo.py`` is also a prefix of
+    ``can://python/app/src/foo.pyX``, so descendants match on ``id + '/'`` and the
+    node itself by equality."""
+    return f"{can_id}/"
+
+
+def application_prefix(app_name: Optional[str]) -> str:
+    """``can://python/<app>/`` — the scope of every destructive statement. Refuses an
+    empty application: ``STARTS WITH ''`` would match every node in the database."""
+    if not app_name:
+        raise ValueError("neo4j: refusing a destructive statement without an application id")
+    return descendant_prefix(f"{_PY_CAN_PREFIX}{app_name}")
 
 
 @dataclass
@@ -100,14 +129,20 @@ class RowBuilder:
         (last write wins) and unions labels — the in-memory analog of
         ``MERGE (n:Label {key}) SET n += props``."""
         node_id = f"{labels[0]} {value}"
+        props = dict(props)
+        module = props.pop("_module", None)  # lifted off the graph (#173)
+        if key_prop == "id" and value.startswith(_PY_CAN_PREFIX) and CAN_NODE not in labels:
+            labels = [*labels, CAN_NODE]
         existing = self._nodes.get(node_id)
         if existing is not None:
             existing.props.update(props)
+            if module is not None:
+                existing.module = module
             for label in labels:
                 if label not in existing.labels:
                     existing.labels.append(label)
         else:
-            self._nodes[node_id] = NodeRow(list(labels), key_prop, value, dict(props))
+            self._nodes[node_id] = NodeRow(list(labels), key_prop, value, props, module)
         self._keys.add((labels[0], value))
         return NodeRef(labels[0], key_prop, value)
 

--- a/codeanalyzer/neo4j/schema.py
+++ b/codeanalyzer/neo4j/schema.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List
 
-SCHEMA_VERSION = "2.0.0"
+SCHEMA_VERSION = "3.0.0"
 
 # PropType ∈ {"string", "integer", "float", "boolean", "string[]", "integer[]"}.
 
@@ -57,7 +57,9 @@ class RelType:
 
 
 # Labels layered onto a node in addition to its primary/specific label.
-MARKER_LABELS: List[str] = []
+# ``PyCanNode`` (#173) rides every node keyed by a ``can://python/`` id — an index
+# anchor for the prefix-scoped destructive statements (see ``rows.CAN_NODE``).
+MARKER_LABELS: List[str] = ["PyCanNode"]
 
 _SPAN = {"start_line": "integer", "end_line": "integer"}
 
@@ -90,7 +92,6 @@ NODE_LABELS: List[NodeLabel] = [
             "content_hash": "string",
             "last_modified": "float",
             "file_size": "integer",
-            "_module": "string",
         },
     ),
     NodeLabel(
@@ -106,7 +107,6 @@ NODE_LABELS: List[NodeLabel] = [
             "decorators": "string[]",
             "docstring": "string",
             **_SPAN,
-            "_module": "string",
             "is_entrypoint": "boolean",
             "entrypoint_frameworks": "string[]",
         },
@@ -130,7 +130,6 @@ NODE_LABELS: List[NodeLabel] = [
             "modifiers": "string[]",
             "parameters_json": "string",
             "accessed_symbols_json": "string",
-            "_module": "string",
             "is_entrypoint": "boolean",
             "entrypoint_frameworks": "string[]",
         },
@@ -159,7 +158,6 @@ NODE_LABELS: List[NodeLabel] = [
             "initializer": "string",
             "docstring": "string",
             **_SPAN,
-            "_module": "string",
         },
     ),
     NodeLabel(
@@ -173,7 +171,6 @@ NODE_LABELS: List[NodeLabel] = [
             "initializer": "string",
             "scope": "string",
             **_SPAN,
-            "_module": "string",
         },
     ),
     # Level-3 CPG overlay (present only at -a 3). The dataflow vocabulary is
@@ -200,7 +197,6 @@ NODE_LABELS: List[NodeLabel] = [
             "is_constructor_call": "boolean",
             "arguments_json": "string",
             **_SPAN,
-            "_module": "string",
         },
     ),
     # Neutral artifact/dependency subgraph (spec 2026-08-27, Task 6). No `Py`
@@ -334,27 +330,14 @@ def uniqueness_constraints() -> list[str]:
 
 CONSTRAINTS: List[str] = uniqueness_constraints()
 
-# The labels this analyzer owns per module -- the ones carrying the internal ``_module``
-# provenance property. Derived from NODE_LABELS so a new module-scoped label is covered
-# without a second list to maintain. `_module` is NOT python-private: codeanalyzer-java
-# and codeanalyzer-typescript set the same property on their nodes, so every statement
-# matching on it must be anchored to these labels or it matches a sibling analyzer's graph
-# in a shared database (#171).
-MODULE_OWNED_LABELS: List[str] = [n.label for n in NODE_LABELS if "_module" in n.properties]
-
-# The label disjunction to anchor such a statement with: ``MATCH (x:PyModule|PyClass|...)``.
-MODULE_OWNED_PATTERN: str = "|".join(MODULE_OWNED_LABELS)
-
 INDEXES: List[str] = [
     "CREATE INDEX py_callable_name IF NOT EXISTS FOR (c:PyCallable) ON (c.name)",
     "CREATE INDEX py_class_name IF NOT EXISTS FOR (c:PyClass) ON (c.name)",
     "CREATE FULLTEXT INDEX py_code_fts IF NOT EXISTS FOR (c:PyCallable) ON EACH [c.code, c.docstring]",
-] + [
-    # One per module-owned label: the incremental writer's per-module purge matches on
-    # `_module` once per changed module, which without these is a label scan per label per
-    # module -- quadratic on a full push (#171).
-    f"CREATE INDEX {label.lower()}_module IF NOT EXISTS FOR (x:{label}) ON (x._module)"
-    for label in MODULE_OWNED_LABELS
+    # #173: every destructive statement is ``MATCH (x:PyCanNode) WHERE x.id STARTS WITH $p``.
+    # A range index on the marker makes that a prefix seek; without it, a store scan per
+    # changed module. STARTS WITH is index-backed; CONTAINS / ENDS WITH are not.
+    "CREATE INDEX py_can_node_id IF NOT EXISTS FOR (n:PyCanNode) ON (n.id)",
 ]
 
 

--- a/docs/skills/analyzing-canpy-graphs/references/vocabulary.md
+++ b/docs/skills/analyzing-canpy-graphs/references/vocabulary.md
@@ -5,15 +5,15 @@
 | label | merge key | properties |
 | --- | --- | --- |
 | `PyApplication` | `name` | analyzer_name, analyzer_version, name, repo_dirty, repo_uri, schema_version, source_revision, entrypoint_frameworks, entrypoint_report_json |
-| `PyModule` | `id` | _module, content_hash, file_key, file_size, id, last_modified, module_name |
-| `PyClass` | `id` | _module, base_classes, code, decorators, docstring, end_line, entrypoint_frameworks, id, is_entrypoint, name, signature, start_line |
-| `PyCallable` | `id` | _module, accessed_symbols_json, code, code_start_line, cyclomatic_complexity, decorators, docstring, end_line, entrypoint_frameworks, id, is_entrypoint, modifiers, name, parameters_json, path, return_type |
+| `PyModule` | `id` | content_hash, file_key, file_size, id, last_modified, module_name |
+| `PyClass` | `id` | base_classes, code, decorators, docstring, end_line, entrypoint_frameworks, id, is_entrypoint, name, signature, start_line |
+| `PyCallable` | `id` | accessed_symbols_json, code, code_start_line, cyclomatic_complexity, decorators, docstring, end_line, entrypoint_frameworks, id, is_entrypoint, modifiers, name, parameters_json, path, return_type |
 | `PyExternal` | `id` | id, module, name — ghosts; member-level (`…/@external/<module>/<name>`) or module-level (`…/@external/<module>`) |
 | `PyPackage` | `name` | name (Python package dirs, not PyPI packages) |
 | `PyDecorator` | `name` | name, qualified_name |
-| `PyAttribute` | `id` | _module, docstring, end_line, id, initializer, name, start_line, type |
-| `PyVariable` | `id` | _module, end_line, id, initializer, name, scope, start_line, type |
-| `PyBodyNode` | `id` (GLOBAL ordinal) | _module, arguments_json, call_node, end_line, id, is_constructor_call, kind, method_name, receiver_expr, receiver_type, return_type, start_line, var |
+| `PyAttribute` | `id` | docstring, end_line, id, initializer, name, start_line, type |
+| `PyVariable` | `id` | end_line, id, initializer, name, scope, start_line, type |
+| `PyBodyNode` | `id` (GLOBAL ordinal) | arguments_json, call_node, end_line, id, is_constructor_call, kind, method_name, receiver_expr, receiver_type, return_type, start_line, var |
 | `Artifact` | `id` (`can://artifact/…`) | extraction, format, id, path, roles, sha256, size_bytes, source — **language-neutral, no Py prefix by design**; every non-`.py` file is inventoried (never-drop), binaries with empty source. `source` is the WHOLE file or `""` (binary, or `--no-artifact-text`) — never a prefix, so it needs no companion flag to be trusted |
 | `Package` | `id` (purl `pkg:pypi/<name>`, `<name>` PEP 503 normalized: lowercase, `[-_.]+` → `-`, so always `pkg:pypi/pyyaml`, never `pkg:pypi/PyYAML`) | ecosystem, id, name — language-neutral |
 
@@ -25,6 +25,13 @@ In `analysis.json` the same value is `body[<local>].id` on every body node, and
 slice starting at the `class`/`def` token. For a nested declaration the first line therefore
 carries no indentation while continuation lines keep theirs; strip `span.start[1]` columns from
 those lines to dedent.
+
+Every node keyed by a `can://python/` id also carries the marker label `PyCanNode`, indexed on
+`id`. Scope a query to one application or one module with a prefix, never with a label list:
+`MATCH (x:PyCanNode) WHERE x.id STARTS WITH 'can://python/<app>/'` (append `<file>/` for one
+module). `PyAttribute` ids are `<class-id>/<name>`; `PyVariable` ids are
+`<owner-id>/<name>@<line>` with the owner a module or a callable. `:PyExternal` ids are
+`can://python/<app>/@external/<module>/<name>`, inside the application prefix.
 
 `PyBodyNode.kind`: `entry`, `exit`, `statement`, `branch`, `loop`, `return`,
 `raise`, `handler`, `call`, `formal_in`, `formal_out`, `actual_in`, `actual_out`.

--- a/schema.neo4j.json
+++ b/schema.neo4j.json
@@ -1,7 +1,9 @@
 {
-  "schema_version": "2.0.0",
+  "schema_version": "3.0.0",
   "generator": "codeanalyzer-python",
-  "marker_labels": [],
+  "marker_labels": [
+    "PyCanNode"
+  ],
   "node_labels": [
     {
       "label": "PyApplication",
@@ -29,8 +31,7 @@
         "module_name": "string",
         "content_hash": "string",
         "last_modified": "float",
-        "file_size": "integer",
-        "_module": "string"
+        "file_size": "integer"
       }
     },
     {
@@ -47,7 +48,6 @@
         "docstring": "string",
         "start_line": "integer",
         "end_line": "integer",
-        "_module": "string",
         "is_entrypoint": "boolean",
         "entrypoint_frameworks": "string[]"
       }
@@ -72,7 +72,6 @@
         "modifiers": "string[]",
         "parameters_json": "string",
         "accessed_symbols_json": "string",
-        "_module": "string",
         "is_entrypoint": "boolean",
         "entrypoint_frameworks": "string[]"
       }
@@ -115,8 +114,7 @@
         "initializer": "string",
         "docstring": "string",
         "start_line": "integer",
-        "end_line": "integer",
-        "_module": "string"
+        "end_line": "integer"
       }
     },
     {
@@ -130,8 +128,7 @@
         "initializer": "string",
         "scope": "string",
         "start_line": "integer",
-        "end_line": "integer",
-        "_module": "string"
+        "end_line": "integer"
       }
     },
     {
@@ -150,8 +147,7 @@
         "is_constructor_call": "boolean",
         "arguments_json": "string",
         "start_line": "integer",
-        "end_line": "integer",
-        "_module": "string"
+        "end_line": "integer"
       }
     },
     {
@@ -512,11 +508,6 @@
     "CREATE INDEX py_callable_name IF NOT EXISTS FOR (c:PyCallable) ON (c.name)",
     "CREATE INDEX py_class_name IF NOT EXISTS FOR (c:PyClass) ON (c.name)",
     "CREATE FULLTEXT INDEX py_code_fts IF NOT EXISTS FOR (c:PyCallable) ON EACH [c.code, c.docstring]",
-    "CREATE INDEX pymodule_module IF NOT EXISTS FOR (x:PyModule) ON (x._module)",
-    "CREATE INDEX pyclass_module IF NOT EXISTS FOR (x:PyClass) ON (x._module)",
-    "CREATE INDEX pycallable_module IF NOT EXISTS FOR (x:PyCallable) ON (x._module)",
-    "CREATE INDEX pyattribute_module IF NOT EXISTS FOR (x:PyAttribute) ON (x._module)",
-    "CREATE INDEX pyvariable_module IF NOT EXISTS FOR (x:PyVariable) ON (x._module)",
-    "CREATE INDEX pybodynode_module IF NOT EXISTS FOR (x:PyBodyNode) ON (x._module)"
+    "CREATE INDEX py_can_node_id IF NOT EXISTS FOR (n:PyCanNode) ON (n.id)"
   ]
 }

--- a/test/test_neo4j_bolt.py
+++ b/test/test_neo4j_bolt.py
@@ -127,7 +127,10 @@ def test_full_push_materializes_the_whole_graph_and_schema(driver, cfg):
 def test_full_run_does_not_prune_another_applications_modules(driver, cfg):
     """Regression for #45: a full-run push for one application must not prune the
     modules of a *different* application sharing the database."""
-    app_a, sig_to_id_a = make_sample_app()
+    app_a, _ = make_sample_app()
+    # Re-stamp under the pushed name: the writer refuses a module whose can:// id
+    # is not under the application it is asked to purge for (#173).
+    sig_to_id_a = assign_ids(app_a, "app-a")
     bolt_writer(project(app_a, "app-a", sig_to_id_a), cfg, full_run=True, eager=True)
     before = _num(driver, "MATCH (:PyApplication {name:'app-a'})-[:PY_HAS_MODULE]->(m) RETURN count(m)")
     assert before > 0
@@ -162,14 +165,16 @@ def test_a_full_run_prunes_a_module_whose_source_vanished(driver, cfg):
     rows = project(app, "sample-app", sig_to_id)
     bolt_writer(rows, cfg, full_run=True, eager=True)
 
-    # The victim's module-scoped nodes are gone.
-    assert _num(driver, "MATCH (n {_module:$m}) RETURN count(n)", m=victim) == 0
+    # The victim's subtree is gone: nothing under its can:// prefix remains.
+    victim_id = app0.symbol_table[victim].id
+    assert _num(driver, "MATCH (n:PyCanNode) WHERE n.id = $mid OR n.id STARTS WITH $pre RETURN count(n)",
+                mid=victim_id, pre=victim_id + "/") == 0
 
-    # The surviving module-scoped graph matches the reduced projection. (Shared
-    # :PyExternal/:PyPackage/:PyDecorator nodes are MERGE-only and never pruned, so we
-    # compare only _module-tagged nodes.)
-    module_scoped = sum(1 for n in rows.nodes if "_module" in n.props)
-    assert _num(driver, "MATCH (n) WHERE n._module IS NOT NULL RETURN count(n)") == module_scoped
+    # The surviving module-owned graph matches the reduced projection. (:PyExternal /
+    # :PyPackage / :PyDecorator are MERGE-only and never pruned, so compare only rows
+    # that have an owning module.)
+    module_scoped = sum(1 for n in rows.nodes if n.module is not None)
+    assert _num(driver, "MATCH (n:PyCanNode) WHERE NOT n.id CONTAINS '/@external/' RETURN count(n)") == module_scoped
 
 
 def test_a_push_never_touches_a_sibling_analyzers_nodes(driver, cfg):
@@ -198,16 +203,56 @@ def test_a_lazy_push_deletes_nothing(driver, cfg):
     app0, sig_to_id0 = make_sample_app()
     rows0 = project(app0, "sample-app", sig_to_id0)
     bolt_writer(rows0, cfg, full_run=True)
-    before = _num(driver, "MATCH (n) WHERE n._module IS NOT NULL RETURN count(n)")
+    before = _num(driver, "MATCH (n:PyCanNode) RETURN count(n)")
 
     app, sig_to_id = make_sample_app()
     victim = sorted(app.symbol_table.keys())[0]
+    victim_pre = app.symbol_table[victim].id + "/"
     del app.symbol_table[victim]
     bolt_writer(project(app, "sample-app", sig_to_id), cfg, full_run=True)
 
-    assert _num(driver, "MATCH (n) WHERE n._module IS NOT NULL RETURN count(n)") == before
-    assert _num(driver, "MATCH (n) WHERE n._module = $m RETURN count(n)", m=victim) > 0
+    assert _num(driver, "MATCH (n:PyCanNode) RETURN count(n)") == before
+    assert _num(driver, "MATCH (n:PyCanNode) WHERE n.id STARTS WITH $pre RETURN count(n)", pre=victim_pre) > 0
 
     # ...and --eager still reconciles it.
     bolt_writer(project(app, "sample-app", sig_to_id), cfg, full_run=True, eager=True)
-    assert _num(driver, "MATCH (n) WHERE n._module = $m RETURN count(n)", m=victim) == 0
+    assert _num(driver, "MATCH (n:PyCanNode) WHERE n.id STARTS WITH $pre RETURN count(n)", pre=victim_pre) == 0
+
+
+def test_eager_push_of_a_second_python_app_with_a_colliding_module_path_leaves_the_first_intact(driver, cfg):
+    """#173: two python applications sharing a module path carry identical labels, so only
+    the id prefix separates them. Both the per-module purge and the orphan prune must
+    stay inside `can://python/<app>/`."""
+    file_key = "appb/main.py"
+    app_a, sig_a = _single_module_app(file_key)
+    app_a_rows = project(app_a, "app-a", assign_ids(app_a, "app-a"))
+    bolt_writer(app_a_rows, cfg, full_run=True, eager=True)
+    a_nodes = _num(driver, "MATCH (n:PyCanNode) WHERE n.id STARTS WITH 'can://python/app-a/' RETURN count(n)")
+    assert a_nodes > 0
+
+    app_b, sig_b = _single_module_app(file_key)
+    bolt_writer(project(app_b, "app-b", sig_b), cfg, full_run=True, eager=True)
+    # ...and again, so app-b's purge runs against a graph that already holds app-b too.
+    bolt_writer(project(app_b, "app-b", sig_b), cfg, full_run=True, eager=True)
+
+    assert _num(driver, "MATCH (n:PyCanNode) WHERE n.id STARTS WITH 'can://python/app-a/' RETURN count(n)") == a_nodes
+    assert _num(driver, "MATCH (:PyApplication {name:'app-a'})-[:PY_HAS_MODULE]->(m) RETURN count(m)") == 1
+    assert _num(driver, "MATCH (:PyApplication {name:'app-b'})-[:PY_HAS_MODULE]->(m) RETURN count(m)") == 1
+
+
+def test_external_nodes_sit_inside_the_application_prefix(driver, cfg):
+    """#179: `:PyExternal` ids carry the application segment, so an external→app call
+    edge is reachable by the same prefix predicate as every other node."""
+    app, sig_to_id = make_sample_app()
+    bolt_writer(project(app, "sample-app", sig_to_id), cfg, full_run=True, eager=True)
+    total = _num(driver, "MATCH (e:PyExternal) RETURN count(e)")
+    assert total >= 1
+    inside = _num(driver, "MATCH (e:PyExternal:PyCanNode) WHERE e.id STARTS WITH 'can://python/sample-app/' RETURN count(e)")
+    assert inside == total
+
+
+def test_eager_push_refuses_an_empty_application_id(driver, cfg):
+    app, sig_to_id = make_sample_app()
+    rows = project(app, "", sig_to_id)
+    with pytest.raises(ValueError):
+        bolt_writer(rows, cfg, full_run=True, eager=True)

--- a/test/test_neo4j_schema.py
+++ b/test/test_neo4j_schema.py
@@ -127,8 +127,11 @@ def test_call_edge_to_imported_module_name_is_not_dropped():
     sig_to_id = assign_ids(app, "app")
     rows = project(app, "app", sig_to_id)
 
+    # #173: an unhomed target lands on an @external ghost under the application
+    # prefix (never a bare-signature id), the same node `_import_ghost` builds.
+    ghost = "can://python/app/@external/os"
     calls_to_os = [
-        e for e in rows.edges if e.type == "PY_CALLS" and e.to_ref.value == "os"
+        e for e in rows.edges if e.type == "PY_CALLS" and e.to_ref.value == ghost
     ]
     assert (
         len(calls_to_os) == 1
@@ -136,7 +139,7 @@ def test_call_edge_to_imported_module_name_is_not_dropped():
 
     # 'os' is materialized as a :PyExternal symbol (the call target) ...
     assert any(
-        n.value == "os" and "PyExternal" in n.labels for n in rows.nodes
+        n.value == ghost and "PyExternal" in n.labels for n in rows.nodes
     ), ":PyExternal ghost for the call target 'os' is missing"
     # ... distinct from the :PyPackage 'os' created by the import.
     assert any(

--- a/test/test_neo4j_scope.py
+++ b/test/test_neo4j_scope.py
@@ -1,0 +1,83 @@
+"""#173: destructive Neo4j statements scope on the ``can://`` id prefix; ``_module`` retires.
+No container needed — these pin the row shape the writers rely on."""
+import pytest
+
+from codeanalyzer.neo4j import NODE_LABELS, project
+from codeanalyzer.neo4j.rows import (
+    CAN_NODE, RowBuilder, application_prefix, descendant_prefix,
+)
+from codeanalyzer.neo4j.schema import INDEXES, MARKER_LABELS, SCHEMA_VERSION
+from codeanalyzer.schema.assign_ids import assign_ids
+
+from sample_graph_app import make_sample_app
+
+
+def test_module_is_lifted_off_emitted_props_and_can_nodes_carry_the_marker():
+    app, sig_to_id = make_sample_app()
+    rows = project(app, "sample-app", sig_to_id)
+    for n in rows.nodes:
+        assert "_module" not in n.props, f"_module still emitted on {n.labels} {n.value}"
+        if n.key_prop == "id" and n.value.startswith("can://python/"):
+            assert CAN_NODE in n.labels, f"{n.value} lacks {CAN_NODE}"
+        else:
+            assert CAN_NODE not in n.labels, f"{n.value} wrongly carries {CAN_NODE}"
+    owned = [n for n in rows.nodes if n.module is not None]
+    assert owned, "module-owned rows must keep their owning module in memory"
+    assert all(n.module in app.symbol_table for n in owned)
+    assert not any("_module" in lbl.properties for lbl in NODE_LABELS)
+    assert MARKER_LABELS == [CAN_NODE]
+    assert any(f"FOR (n:{CAN_NODE}) ON (n.id)" in stmt for stmt in INDEXES)
+    assert not any("_module" in stmt for stmt in INDEXES)
+    assert SCHEMA_VERSION == "3.0.0"
+
+
+def test_attribute_and_variable_ids_hang_under_their_owner_can_id():
+    app, sig_to_id = make_sample_app()
+    rows = project(app, "sample-app", sig_to_id)
+    attrs = [n for n in rows.nodes if n.labels[0] == "PyAttribute"]
+    variables = [n for n in rows.nodes if n.labels[0] == "PyVariable"]
+    assert attrs and variables, "sample app must have an attribute and a variable"
+    owners = {n.value for n in rows.nodes if n.labels[0] in ("PySymbol", "PyModule")}
+    for n in attrs + variables:
+        owner, _, leaf = n.value.rpartition("/")
+        assert owner in owners, f"{n.value} is not under a declared owner"
+        assert n.value.startswith("can://python/sample-app/")
+    assert all("@" in n.value.rsplit("/", 1)[1] for n in variables)  # <name>@<line>
+
+
+def test_two_application_names_never_share_an_id_keyed_node():
+    app, sig_to_id = make_sample_app()
+    a = {n.value for n in project(app, "app-a", assign_ids(app, "app-a")).nodes if n.key_prop == "id"}
+    b = {n.value for n in project(app, "app-b", assign_ids(app, "app-b")).nodes if n.key_prop == "id"}
+    # Ids minted at ANALYSIS time carry that run's app name, not the projection's:
+    # artifacts (`discover_artifacts(project_dir, app_name)`) and the externals
+    # `_home_external_symbols` registers. Everything `project()` mints must differ.
+    shared = {
+        v for v in a & b
+        if not v.startswith(("pkg:", "can://artifact/")) and "/@external/" not in v
+    }
+    assert shared == set(), f"ids shared across applications: {sorted(shared)[:5]}"
+    assert all(v.startswith("can://") for v in a | b if not v.startswith("pkg:")), \
+        "every id-keyed node is a can:// node"
+
+
+def test_prefix_helpers_guard_the_two_ways_this_goes_wrong():
+    assert descendant_prefix("can://python/app/src/foo.py") == "can://python/app/src/foo.py/"
+    assert application_prefix("app") == "can://python/app/"
+    for bad in ("", None):
+        with pytest.raises(ValueError):
+            application_prefix(bad)
+
+
+def test_row_builder_lifts_module_and_marks_only_python_can_ids():
+    b = RowBuilder()
+    r1 = b.node(["PyModule"], "id", "can://python/app/m.py", {"_module": "m.py", "x": 1})
+    b.node(["Artifact"], "id", "can://artifact/app/Dockerfile", {"_module": "Dockerfile"})
+    b.node(["PyDecorator"], "name", "functools.lru_cache", {"name": "functools.lru_cache"})
+    rows = b.finish()
+    by = {n.value: n for n in rows.nodes}
+    assert by[r1.value].props == {"x": 1} and by[r1.value].module == "m.py"
+    assert CAN_NODE in by[r1.value].labels
+    assert CAN_NODE not in by["can://artifact/app/Dockerfile"].labels
+    assert by["can://artifact/app/Dockerfile"].module == "Dockerfile"
+    assert CAN_NODE not in by["functools.lru_cache"].labels


### PR DESCRIPTION
Closes #173, closes #179. Spec: codellm-devkit/.github `docs/design/specs/2026-09-02-prune-scope-on-can-id-prefix.md` (epic codellm-devkit/.github#50). Reference implementation: codeanalyzer-java#220.

Every delete (the per-module purge, the full-run orphan prune, the snapshot wipe) matches `x.id = <id> OR x.id STARTS WITH <id> + '/'` instead of a label list plus `_module`. The id carries language, application and file, so a prefix match is containment and separates two python applications sharing a module path, which no label anchor can (identical labels). `_module` leaves the graph, the catalog and its six per-label indexes; `RowBuilder` lifts it into an in-memory field so the incremental diff still groups by module and no projector site changes. `:PyCanNode` marks every node keyed by a `can://python/` id, with a range index on `id`: an anchor so the prefix predicate seeks instead of scanning. An empty application id is refused rather than becoming `STARTS WITH ''`.

`:PyAttribute` / `:PyVariable` ids now hang under the owner's `can://` id (`<class-id>/<name>`, `<owner-id>/<name>@<line>`); the signature-minted ids they replace carried no application segment and MERGEd across applications. An unhomed call target lands on an `@external` ghost under the application prefix, never a bare-signature id, so `:PyExternal` sits inside the application scope (#179).

Also fixed: the `content_hash` diff compared a module's `can://` id against a file key (every module always counted as changed) and keyed the database side by file key (a second application's identical module was never written).

**BREAKING:** graph contract 2.0.0 → 3.0.0. A consumer that filtered on `x._module` filters on `x.id STARTS WITH 'can://python/<app>/<file>/'` instead.

Gates: v2/neo4j/dataflow 188 passed (one #146 Jedi flake, passed solo); Bolt container suite 9 passed against neo4j:5, including a second python app with a colliding module path surviving an eager push, externals inside the app prefix, and an empty app id refused; entrypoints/artifacts/symbol-table 195 passed; config 81 passed; CLI emit gates 5 passed. `test_cli.py` was memory-killed locally on every attempt and is left to CI; the branch touches only `codeanalyzer/neo4j/`.
