### PR TITLE
feat(entrypoints): heuristic tier on the written decorator spelling; odoo GET+POST; quieter unresolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A framework-independent **heuristic tier** for entrypoints. A decorator whose
+  written spelling reads as an HTTP hook (`route`, `*.route`, `*.*.route`, or
+  `*.get`/`.post`/`.put`/`.patch`/`.delete`/`.head`/`.options`/`.websocket`,
+  one or two segments deep) is recorded with `framework: "heuristic"`,
+  `confidence: "heuristic"` and rule id `heuristic.http-route` /
+  `heuristic.http-verb`, whether or not any framework was detected or any
+  framework rule knows the library. Route and methods come from the arguments
+  the same way as framework rules; a node a framework rule already matched gets
+  no heuristic record. Shipped as a `heuristics:` block in `rules.yml`,
+  disableable by id like every other rule. `*` now keeps its meaning inside a
+  `{a,b}` alternation.
 - `BodyNode.id` and `PyCallableParameter.id` in `analysis.json` (#176). A body
   node's `id` is the global ordinal `<callable-id>@<local>` the Neo4j projection
   already merges `:PyBodyNode` on, present at every level the node exists; a
@@ -37,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The odoo entrypoint rule's default methods are `[GET, POST]`, not `[GET]`:
+  Odoo serves both on a route unless `methods=` narrows it, and json-typed
+  routes are POST.
 - **BREAKING (graph contract 3.0.0):** every destructive Neo4j statement is
   scoped on the `can://` id prefix, and the internal `_module` property retires
   from every node, from the catalog and from its six per-label indexes (#173,
@@ -65,6 +79,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `can://` id; anything else lands on an `@external` ghost with the same id
   shape call targets use. Relative imports resolve through `resolved_module`
   for entrypoint base matching too.
+- `PyEntrypointReport.unresolved` no longer counts what is nameable: Python
+  builtins (`object`, `Exception`, `str`), subscripted generics
+  (`typing.Generic[T]`, `dict[K, V]`) and any spelling whose head is an
+  imported name or a declared class. On Odoo it listed 24 `Exception` and 20
+  `object` bases as unresolved.
 - `PyEntrypointReport.unresolved` is now written (#177). It had no writer at
   all, so it read `{}` on every run; it now counts, per written spelling, the
   decorators and base classes that neither Jedi nor the import table could

--- a/codeanalyzer/entrypoints/matching.py
+++ b/codeanalyzer/entrypoints/matching.py
@@ -64,7 +64,8 @@ def _compile(pattern: str) -> str:
         if ch == "{":
             j = pattern.index("}", i)
             alts = pattern[i + 1 : j].split(",")
-            out.append("(?:" + "|".join(re.escape(a.strip()) for a in alts) + ")")
+            # `*` keeps its meaning inside an alternative, so `{route,*.route}` works.
+            out.append("(?:" + "|".join(_compile(a.strip()) for a in alts) + ")")
             i = j + 1
         elif ch == "*":
             out.append(r"[^.\s]*")
@@ -119,15 +120,21 @@ def entrypoints_from_decorators(
     framework: str,
     rules: Iterable["DecoratorRule"],
     resolve: Optional[Callable[[str], str]] = None,
+    on_written: bool = False,
 ) -> List[PyEntrypoint]:
     """``resolve`` is the module's import-table resolver (#177): when Jedi could
     not resolve a decorator (the framework is not importable in the analysis
     environment -- every ``--no-venv`` run), ``@http.route`` still resolves to
     ``odoo.http.route`` from ``from odoo import http`` alone, the same way base
-    classes already do. Jedi's definition path wins when it exists."""
+    classes already do. Jedi's definition path wins when it exists.
+
+    ``on_written`` is the heuristic tier: rules match the decorator's spelling
+    as WRITTEN (``http.route``, ``router.post``), no resolution at all, so a
+    shape that reads as an HTTP entrypoint is recorded whether or not any
+    framework rule knows the library behind it."""
     out: List[PyEntrypoint] = []
     for dec in getattr(node, "decorators", []) or []:
-        qualified = decorator_qualified_name(dec, resolve)
+        qualified = dec.name if on_written else decorator_qualified_name(dec, resolve)
         for rule in rules:
             if not match_pattern(rule.match, qualified):
                 continue

--- a/codeanalyzer/entrypoints/pipeline.py
+++ b/codeanalyzer/entrypoints/pipeline.py
@@ -6,8 +6,9 @@ loses flags, never the analysis.
 """
 from __future__ import annotations
 
+import builtins
 from pathlib import Path
-from typing import Dict, Iterable, Iterator
+from typing import Dict, Iterable, Iterator, Set
 
 from codeanalyzer.entrypoints.detect import detected_frameworks
 from codeanalyzer.entrypoints.matching import (
@@ -68,16 +69,18 @@ def _run_stages(app: PyApplication, project_dir: Path, rules: RuleSet) -> None:
     unresolved = app.entrypoint_report.unresolved
     for mod in app.symbol_table.values():
         resolve = _base_resolver(mod)
-        declared = {cl.name for cl in (mod.types or {}).values()}
+        known = _known_heads(mod)
         for node in _walk_module(mod):
             # #177: what neither Jedi nor the import table could name. This is
             # the counter that makes silence visible; it was never written before.
+            # A builtin, a declared class, or a name whose head is imported is
+            # nameable and is not counted (`object`, `Exception`, `typing.Generic[T]`).
             for dec in getattr(node, "decorators", None) or []:
-                if decorator_qualified_name(dec, resolve) is None:
+                if decorator_qualified_name(dec, resolve) is None and _unnameable(dec.name, known):
                     unresolved[dec.name] = unresolved.get(dec.name, 0) + 1
             if isinstance(node, PyClass):
                 for base in node.base_classes or []:
-                    if base not in declared and resolve(base) == base:
+                    if _unnameable(base, known):
                         unresolved[base] = unresolved.get(base, 0) + 1
             for name in names:
                 fw = rules.frameworks[name]
@@ -93,6 +96,34 @@ def _run_stages(app: PyApplication, project_dir: Path, rules: RuleSet) -> None:
                         target = (node.callables or {}).get(method_name)
                         if target is not None:
                             target.entrypoints.extend(eps)
+            # Heuristic tier: the written spelling, no framework needed. Runs
+            # last so a node a framework rule already claimed keeps one record.
+            if not node.entrypoints and rules.heuristics:
+                node.entrypoints.extend(
+                    entrypoints_from_decorators(
+                        node, "heuristic", rules.heuristics, resolve, on_written=True
+                    )
+                )
+
+
+_BUILTIN_NAMES: Set[str] = set(dir(builtins))
+
+
+def _known_heads(mod: PyModule) -> Set[str]:
+    """Names that can head a nameable spelling in this module: its declared classes
+    and every imported name or alias."""
+    heads = {cl.name for cl in (mod.types or {}).values()}
+    for imp in mod.imports or []:
+        heads.add(imp.alias or imp.name)
+    return heads
+
+
+def _unnameable(written: str, known: Set[str]) -> bool:
+    """Whether a written base/decorator spelling maps to nothing this module can
+    name: not a builtin, not a declared class, and its head is not imported.
+    Subscripts (`Generic[T]`, `dict[K, V]`) are stripped before the check."""
+    head = written.split("[", 1)[0].split(".", 1)[0].strip()
+    return bool(head) and head not in _BUILTIN_NAMES and head not in known
 
 
 def _base_resolver(mod: PyModule):

--- a/codeanalyzer/entrypoints/rules.py
+++ b/codeanalyzer/entrypoints/rules.py
@@ -22,7 +22,7 @@ _CONFIDENCE = {"declared", "certain", "heuristic"}
 # blocks (Units 4-5) not implemented yet; they are deliberately absent here
 # rather than accepted-and-ignored, so a user file using them fails loudly
 # instead of loading clean and doing nothing.
-_TOP_LEVEL_KEYS = {"version", "frameworks", "disable"}
+_TOP_LEVEL_KEYS = {"version", "frameworks", "heuristics", "disable"}
 
 
 class RulesError(Exception):
@@ -60,6 +60,10 @@ class Framework:
 @dataclass
 class RuleSet:
     frameworks: Dict[str, Framework] = field(default_factory=dict)
+    # Framework-independent decorator rules matched on the WRITTEN spelling,
+    # confidence `heuristic` by default. They run on every node regardless of
+    # `frameworks_detected` and never double a record a framework rule made.
+    heuristics: List[DecoratorRule] = field(default_factory=list)
     rulesets: List[str] = field(default_factory=list)
 
 
@@ -103,9 +107,16 @@ def _merge(out: RuleSet, data: Dict[str, Any], origin: str) -> None:
         for raw in body.get("bases") or []:
             fw.bases.append(_base_rule(raw, origin))
 
+    heuristics = data.get("heuristics") or {}
+    if not isinstance(heuristics, dict):
+        raise RulesError(f"{origin}: `heuristics` must be a mapping")
+    for raw in heuristics.get("decorators") or []:
+        out.heuristics.append(_decorator_rule({"confidence": "heuristic", **raw}, origin))
+
     for fw in out.frameworks.values():
         fw.decorators = [r for r in fw.decorators if r.id not in disabled]
         fw.bases = [r for r in fw.bases if r.id not in disabled]
+    out.heuristics = [r for r in out.heuristics if r.id not in disabled]
 
 
 def _disable_list(data: Dict[str, Any], origin: str) -> List[str]:

--- a/codeanalyzer/entrypoints/rules.yml
+++ b/codeanalyzer/entrypoints/rules.yml
@@ -28,11 +28,13 @@ frameworks:
       # `route` is a plain function in odoo/http.py, so Jedi's definition path
       # and the import-table fallback (`from odoo import http` + `@http.route`,
       # the shape every --no-venv run sees) both spell it `odoo.http.route`.
-      # The first positional may be one route or a list of them.
+      # The first positional may be one route or a list of them. Odoo serves
+      # GET and POST on a route unless `methods=` narrows it (json-typed routes
+      # are POST), so the default is both, not GET.
       - id: odoo.route
         match: "odoo.http.route"
         route: {from: positional, index: 0}
-        methods: {from: keyword, name: methods, default: [GET]}
+        methods: {from: keyword, name: methods, default: [GET, POST]}
     bases:
       - id: odoo.controller
         match: "odoo.http.Controller"
@@ -102,3 +104,19 @@ frameworks:
         match: "django.views.generic.*"
         transitive: true
         dispatch: [get, post, put, patch, delete, head, options]
+
+# Framework-independent tier. Matched on the decorator's WRITTEN spelling, never
+# on a resolved name, so a shape that reads as an HTTP entrypoint is flagged even
+# when the library behind it has no `frameworks:` block above (or is not
+# importable). Confidence `heuristic`; a consumer wanting only certain hits
+# filters on it. A node a framework rule already matched gets no heuristic record.
+heuristics:
+  decorators:
+    - id: heuristic.http-route
+      match: "{route,*.route,*.*.route}"
+      route: {from: positional, index: 0}
+      methods: {from: keyword, name: methods}
+    - id: heuristic.http-verb
+      match: "{*,*.*}.{get,post,put,patch,delete,head,options,websocket}"
+      route: {from: positional, index: 0}
+      methods: {from: match_suffix}

--- a/test/test_entrypoint_decorators.py
+++ b/test/test_entrypoint_decorators.py
@@ -61,3 +61,27 @@ def test_unresolved_decorator_never_matches():
     fn.decorators.append(PyDecorator(name="app.route", qualified_name=None))
     rule = DecoratorRule(id="flask.route", match="flask.Flask.route")
     assert entrypoints_from_decorators(fn, "flask", [rule]) == []
+
+
+def test_wildcard_inside_alternation_expands():
+    from codeanalyzer.entrypoints.matching import match_pattern
+    assert match_pattern("{route,*.route,*.*.route}", "route")
+    assert match_pattern("{route,*.route,*.*.route}", "http.route")
+    assert match_pattern("{route,*.route,*.*.route}", "odoo.http.route")
+    assert not match_pattern("{route,*.route,*.*.route}", "a.b.c.route")
+
+
+def test_heuristic_rules_match_the_written_spelling_without_a_framework():
+    from codeanalyzer.entrypoints.matching import entrypoints_from_decorators
+    from codeanalyzer.entrypoints.rules import load_rules
+    from codeanalyzer.schema.py_schema import PyCallable, PyDecorator
+    fn = PyCallable(name="f", path="a.py", signature="a.f")
+    fn.decorators.append(PyDecorator(name="http.route", qualified_name=None,
+                                     positional_arguments=['"/x"']))
+    fn.decorators.append(PyDecorator(name="router.post", qualified_name=None,
+                                     positional_arguments=['"/y"']))
+    eps = entrypoints_from_decorators(fn, "heuristic", load_rules().heuristics, None, on_written=True)
+    assert [(e.rule, e.route, e.http_methods, e.confidence, e.evidence) for e in eps] == [
+        ("heuristic.http-route", "/x", [], "heuristic", "http.route"),
+        ("heuristic.http-verb", "/y", ["POST"], "heuristic", "router.post"),
+    ]

--- a/test/test_entrypoint_pipeline.py
+++ b/test/test_entrypoint_pipeline.py
@@ -228,7 +228,7 @@ def test_odoo_controller_detected_through_import_table_fallback(tmp_path: Path):
     index = mod.types["Ctl"].callables["index"]
     assert [e.rule for e in index.entrypoints] == ["odoo.route"]
     assert index.entrypoints[0].route == "/x"
-    assert index.entrypoints[0].http_methods == ["GET"]
+    assert index.entrypoints[0].http_methods == ["GET", "POST"]
     assert index.entrypoints[0].evidence == "odoo.http.route"
     assert [e.rule for e in mod.types["Ctl"].entrypoints] == ["odoo.controller"]
 
@@ -242,3 +242,51 @@ def test_report_counts_decorators_and_bases_nothing_resolves(tmp_path: Path):
     assert app.entrypoint_report.unresolved == {"whatever.deco": 1, "Nowhere": 1}
     detect_entrypoints(app, tmp_path)  # idempotent on a warm cache
     assert app.entrypoint_report.unresolved == {"whatever.deco": 1, "Nowhere": 1}
+
+
+def test_heuristic_tier_flags_http_decorators_with_no_framework_detected(tmp_path: Path):
+    """A method spelled `@http.route` is an entrypoint whether or not a framework rule
+    exists for it. The heuristic tier runs regardless of `frameworks_detected`, and
+    never doubles a record a framework rule already made."""
+    from codeanalyzer.schema.py_schema import PyCallable, PyClass, PyDecorator, PyModule
+    index = PyCallable(name="index", path="c.py", signature="c.Ctl.index")
+    index.decorators.append(PyDecorator(name="http.route", qualified_name=None,
+                                        positional_arguments=['"/x"']))
+    ctl = PyClass(name="Ctl", signature="c.Ctl", base_classes=["http.Controller"],
+                  callables={"index": index})
+    mod = PyModule(file_path="c.py", module_name="c", imports=[], types={"Ctl": ctl})
+    app = PyApplication(symbol_table={"c.py": mod})
+    detect_entrypoints(app, tmp_path)
+    assert app.entrypoint_report.frameworks_detected == []
+    assert [(e.framework, e.rule, e.route, e.confidence) for e in index.entrypoints] == [
+        ("heuristic", "heuristic.http-route", "/x", "heuristic")
+    ]
+    assert index.is_entrypoint is True
+
+    # with the odoo import present the framework rule wins and the heuristic stays silent
+    mod2 = _odoo_module()
+    app2 = PyApplication(symbol_table={"c.py": mod2})
+    detect_entrypoints(app2, tmp_path)
+    idx2 = mod2.types["Ctl"].callables["index"]
+    assert [e.rule for e in idx2.entrypoints] == ["odoo.route"]
+    assert idx2.entrypoints[0].http_methods == ["GET", "POST"]
+
+
+def test_unresolved_skips_builtins_generics_and_imported_heads(tmp_path: Path):
+    from codeanalyzer.schema.py_schema import PyCallable, PyClass, PyDecorator, PyImport, PyModule
+    f = PyCallable(name="f", path="c.py", signature="c.f")
+    f.decorators.append(PyDecorator(name="property", qualified_name=None))
+    f.decorators.append(PyDecorator(name="functools.lru_cache", qualified_name=None))
+    f.decorators.append(PyDecorator(name="mystery.deco", qualified_name=None))
+    classes = {
+        "A": PyClass(name="A", signature="c.A", base_classes=["object", "Exception"]),
+        "B": PyClass(name="B", signature="c.B", base_classes=["typing.Generic[T]", "dict[K, V]"]),
+        "C": PyClass(name="C", signature="c.C", base_classes=["Nowhere", "A"]),
+    }
+    mod = PyModule(file_path="c.py", module_name="c",
+                   imports=[PyImport(module="functools", name="functools"),
+                            PyImport(module="typing", name="typing")],
+                   types=classes, functions={"f": f})
+    app = PyApplication(symbol_table={"c.py": mod})
+    detect_entrypoints(app, tmp_path)
+    assert app.entrypoint_report.unresolved == {"mystery.deco": 1, "Nowhere": 1}

--- a/test/test_entrypoint_rules.py
+++ b/test/test_entrypoint_rules.py
@@ -115,3 +115,14 @@ def test_nested_brace_in_match_pattern_is_rejected(tmp_path):
     )
     with pytest.raises(RulesError):
         load_rules([bad])
+
+
+def test_shipped_heuristics_load_and_are_disableable(tmp_path):
+    rs = load_rules()
+    ids = {r.id for r in rs.heuristics}
+    assert {"heuristic.http-route", "heuristic.http-verb"} <= ids
+    assert all(r.confidence == "heuristic" for r in rs.heuristics)
+    user = tmp_path / "u.yml"
+    user.write_text("disable: [heuristic.http-route]\n")
+    rs = load_rules([user])
+    assert "heuristic.http-route" not in {r.id for r in rs.heuristics}


### PR DESCRIPTION
Closes #184.

A decorator that reads as an HTTP hook (`route`, `*.route`, `*.*.route`, or a one- or two-segment `.get`/`.post`/`.put`/`.patch`/`.delete`/`.head`/`.options`/`.websocket`) is now an entrypoint on its own, recorded with `framework: "heuristic"`, `confidence: "heuristic"` and rule id `heuristic.http-route` / `heuristic.http-verb`, whether or not a framework was detected or any framework rule knows the library. Route and methods come from the decorator arguments exactly as framework rules take them; a node a framework rule already matched gets no heuristic record. Shipped as a `heuristics:` block in `rules.yml`, disableable by id like every other rule. `*` now keeps its meaning inside a `{a,b}` alternation. No schema change: `confidence: "heuristic"` already existed.

Also: the odoo rule's default methods are `[GET, POST]` (Odoo serves both unless `methods=` narrows the route; json-typed routes are POST), and `PyEntrypointReport.unresolved` stops counting the nameable (builtins, subscripted generics, spellings whose head is imported or declared).

Verified on `odoo_slim` (1,626 modules, `-a 1 --no-venv --ray`):

| run | result |
| --- | --- |
| odoo rules disabled via user rules file | 534 `heuristic.http-route`, 0 framework records |
| default rules | 534 `odoo.route` with `[GET, POST]` where the decorator says nothing, 94 `odoo.controller`, 0 heuristic records |
| `unresolved` | builtins gone; top entries are real unknowns (`nary_condition_optimization`, `peer_connection.on`) |

Gates: entrypoint, rules, decorator, artifact, symbol-table, conformance, schema and config suites, 317 passed. `test_cli.py` left to CI (memory-killed locally, as with the previous four PRs).
