### PR TITLE
chore(neo4j): graph contract version stays 2.0.0 for the unreleased v2 line

### DIFF
--- a/.claude/SCHEMA_DECISIONS.md
+++ b/.claude/SCHEMA_DECISIONS.md
@@ -472,5 +472,7 @@ Reference implementation: codeanalyzer-java#220.
 - **No bare-signature ids remain.** `_call_endpoint`'s last-resort ghost now
   mints `<app>/@external/<module>/<name>` (the `_home_external_symbols` shape),
   so java's "legacy ids cannot be prefix-scoped" case has no python analogue.
-- Graph contract `2.0.0 → 3.0.0` (a property removed). `analysis.json` is
+- Graph contract stays `2.0.0` although a property was removed: the v2 line
+  has no released consumer pinning the graph contract, so the number does not
+  move until one exists (ruled 2026-09-05). `analysis.json` is
   untouched; `_module` never appeared there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The odoo entrypoint rule's default methods are `[GET, POST]`, not `[GET]`:
   Odoo serves both on a route unless `methods=` narrows it, and json-typed
   routes are POST.
-- **BREAKING (graph contract 3.0.0):** every destructive Neo4j statement is
+- **BREAKING (graph contract, version stays 2.0.0 — the v2 line has no released consumer):** every destructive Neo4j statement is
   scoped on the `can://` id prefix, and the internal `_module` property retires
   from every node, from the catalog and from its six per-label indexes (#173,
   epic codellm-devkit/.github#50). The per-module purge matches the module by

--- a/codeanalyzer/neo4j/schema.py
+++ b/codeanalyzer/neo4j/schema.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List
 
-SCHEMA_VERSION = "3.0.0"
+SCHEMA_VERSION = "2.0.0"
 
 # PropType ∈ {"string", "integer", "float", "boolean", "string[]", "integer[]"}.
 

--- a/schema.neo4j.json
+++ b/schema.neo4j.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "3.0.0",
+  "schema_version": "2.0.0",
   "generator": "codeanalyzer-python",
   "marker_labels": [
     "PyCanNode"

--- a/test/test_neo4j_scope.py
+++ b/test/test_neo4j_scope.py
@@ -28,7 +28,7 @@ def test_module_is_lifted_off_emitted_props_and_can_nodes_carry_the_marker():
     assert MARKER_LABELS == [CAN_NODE]
     assert any(f"FOR (n:{CAN_NODE}) ON (n.id)" in stmt for stmt in INDEXES)
     assert not any("_module" in stmt for stmt in INDEXES)
-    assert SCHEMA_VERSION == "3.0.0"
+    assert SCHEMA_VERSION == "2.0.0"  # the v2 line is unreleased; no consumer pins the graph contract
 
 
 def test_attribute_and_variable_ids_hang_under_their_owner_can_id():


### PR DESCRIPTION
Reverts the 2.0.0 → 3.0.0 bump #183 made to the Neo4j graph contract. The v2 line has no released consumer pinning the graph contract, so the number does not move; `analysis.json` `schema_version` was already unchanged. `schema.neo4j.json` regenerated, changelog and decision log reworded.