### PR TITLE
fix(neo4j): dump the entrypoint report through the pydantic compat shim

### DIFF
--- a/codeanalyzer/neo4j/project.py
+++ b/codeanalyzer/neo4j/project.py
@@ -48,6 +48,7 @@ from codeanalyzer.schema import (
     PyModule,
     PyVariableDeclaration,
 )
+from codeanalyzer.schema import model_dump
 from codeanalyzer.schema.ids import application_id, global_ordinal, purl_pypi
 from codeanalyzer.schema.py_schema import PyDecorator
 
@@ -76,7 +77,7 @@ def project(app: PyApplication, app_name: str, sig_to_id: dict,
                 # pass found nothing". Always present, even when empty.
                 "entrypoint_frameworks": list(app.entrypoint_report.frameworks_detected),
                 "entrypoint_report_json": json.dumps(
-                    app.entrypoint_report.model_dump(), sort_keys=True
+                    model_dump(app.entrypoint_report, mode="json"), sort_keys=True
                 ),
             }
         ),


### PR DESCRIPTION
The v1.4.1 release run failed its Python 3.10 compat leg: `:PyApplication.entrypoint_report_json` called `model_dump()`, a pydantic v2 method, and that leg resolves pydantic 1.x, so every `--emit neo4j` run raised. Routed through `codeanalyzer.schema.model_dump` (`.dict()`/`.json()` on v1). Verified under pydantic 1.10.26 and 2.x; the tag is re-cut on this commit.