### PR TITLE
fix(sdg): param_in/param_out carry the formal's var in JSON and on PY_PARAM_IN/OUT

### DIFF
--- a/.claude/SCHEMA_DECISIONS.md
+++ b/.claude/SCHEMA_DECISIONS.md
@@ -536,3 +536,24 @@ codeanalyzer-typescript. Terms coined once and shared: `SCHEME`, `LANG`,
   no new gate either: `_cache_analyzer_matches` already discards a cache
   written by a different analyzer version, which is exactly the migration
   boundary here.
+
+## 2026-09-09 — `param_in`/`param_out` edges carry `var` (issue #195)
+
+- **Both projections, same value.** `ParamEdge.var` in `analysis.json` and the
+  `var` property on `PY_PARAM_IN`/`PY_PARAM_OUT` are the callee-side formal's
+  variable: the parameter name for `param_in` and for by-reference `param_out`,
+  `<return>` for the return port. It is what `assemble_sdg` already set on every
+  `SDGEdge` of those types (`dataflow/sdg.py`, four construction sites) and what
+  the formal vertex itself carries as `var`/`of`; `emit_l4` was dropping it when
+  it built the JSON edge, and the projector wrote no properties at all while the
+  catalog declared one. Present on **every** edge, never partial — a partially
+  present property is the same three-valued trap one step along.
+- **Why write rather than drop the declaration.** codeanalyzer-typescript emits
+  `param_in[].var` in JSON and writes it to the graph; java declares it and
+  writes nothing (same divergence python had, filed separately). The keystone
+  table lists no attributes on `param_in`/`param_out` and is behind both
+  analyzers — a keystone follow-on. Dropping would have foreclosed the
+  variable-granular interprocedural cut the SDK's taint surface wants.
+- Additive field, `schema_version` unchanged. A 1.5.0 `analysis.json` still
+  parses (`var` defaults to `None`); consumers should tolerate its absence for
+  one generation of cached graphs.

--- a/README.md
+++ b/README.md
@@ -502,7 +502,8 @@ just populate more of the same tree:
         { "id": "can://<app>/@external/os/getcwd", "kind": "external",
           "name": "getcwd", "module": "os" }
     },
-    "param_in":  [ { "src": "can://…/main(a)@6:4/actual_in:0", "dst": "can://…/helper(x)@formal_in:0" } ],
+    "param_in":  [ { "src": "can://…/main(a)@6:4/actual_in:0", "dst": "can://…/helper(x)@formal_in:0",
+                     "var": "x" } ],                                    // var = the callee formal
     "param_out": [ { "src": "can://…/helper(x)@formal_out",   "dst": "can://…/main(a)@6:4/actual_out" } ]
   }
 }

--- a/codeanalyzer/dataflow/builder.py
+++ b/codeanalyzer/dataflow/builder.py
@@ -565,6 +565,7 @@ def emit_l4(
             edge = ParamEdge(
                 src=src_im.global_id(e.source_node),
                 dst=dst_im.global_id(e.target_node),
+                var=e.var,
             )
             (app.param_in if e.type == "PARAM_IN" else app.param_out).append(edge)
 

--- a/codeanalyzer/neo4j/project.py
+++ b/codeanalyzer/neo4j/project.py
@@ -257,17 +257,23 @@ def _project_program_graphs(
     # endpoint functions' identity maps), so they land on the very PyBodyNode ids
     # projected above — a formal_in global id equals _global_ordinal(callee.id,
     # "@formal_in:0"). No dangling references.
+    # `var` (#195): the callee-side formal's variable, set on every edge by the
+    # SDG assembler and carried on `ParamEdge.var`. The catalog declared it and
+    # nothing wrote it, so `r.var` predicates went three-valued across every
+    # call boundary.
     for e in app.param_in or []:
         b.edge(
             "PY_PARAM_IN",
             NodeRef("PyBodyNode", "id", e.src),
             NodeRef("PyBodyNode", "id", e.dst),
+            prune({"var": e.var}),
         )
     for e in app.param_out or []:
         b.edge(
             "PY_PARAM_OUT",
             NodeRef("PyBodyNode", "id", e.src),
             NodeRef("PyBodyNode", "id", e.dst),
+            prune({"var": e.var}),
         )
 
 

--- a/codeanalyzer/schema/py_schema.py
+++ b/codeanalyzer/schema/py_schema.py
@@ -171,7 +171,12 @@ class SummaryEdge(BaseModel):
 
 @builder
 class ParamEdge(BaseModel):
+    """A `param_in` (actual_in → formal_in) or `param_out` (formal_out → actual_out)
+    edge at application scope. `var` is the callee-side formal's variable — the
+    parameter name, or `<return>` for the return port — always set (#195), the
+    same value codeanalyzer-typescript carries on its `param_in[].var`."""
     src: str; dst: str
+    var: Optional[str] = None
 
 
 @builder

--- a/test/test_neo4j_schema.py
+++ b/test/test_neo4j_schema.py
@@ -154,3 +154,21 @@ def test_checked_in_schema_matches_catalog():
     on_disk = json.loads(on_disk_path.read_text())
     fresh = build_schema_document()
     assert on_disk == fresh
+
+
+def test_param_edges_carry_every_declared_property():
+    """#195: the catalog declared `var` on PY_PARAM_IN/PY_PARAM_OUT and the projection
+    wrote none, so a predicate on `r.var` went three-valued across every call boundary.
+    Every emitted edge of those types now carries every declared property — present on
+    all of them, not some, because a partially-present property is the same trap."""
+    app, sig_to_id = make_sample_app()
+    rows = project(app, "sample-app", sig_to_id)
+    for rel in ("PY_PARAM_IN", "PY_PARAM_OUT"):
+        edges = [e for e in rows.edges if e.type == rel]
+        assert edges, f"precondition: the L4 sample must emit {rel}"
+        declared = set(_REL_BY_TYPE[rel].properties)
+        for e in edges:
+            missing = declared - set(e.props)
+            assert not missing, f"{rel} {e.from_ref.value} -> {e.to_ref.value} lacks {missing}"
+            assert e.props["var"], f"{rel} var must be non-empty"
+

--- a/test/test_v2_l4.py
+++ b/test/test_v2_l4.py
@@ -428,3 +428,25 @@ def test_cli_a4_default_graphs_succeeds(tmp_path: Path):
     assert result.returncode == 0, f"Expected exit 0, got {result.returncode}. stderr: {result.stderr}"
     # Verify output was written
     assert (output_dir / "analysis.json").exists()
+
+
+def test_param_edges_carry_the_formal_variable(tmp_path):
+    """#195: `param_in`/`param_out` name the callee-side formal's variable on every
+    edge — the parameter name, or `<return>` for the return port — matching the
+    `var` the formal vertex itself carries and the value typescript emits."""
+    import sys
+    sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent))
+    from sample_graph_app import make_sample_app
+    app, _ = make_sample_app()
+    assert app.param_in and app.param_out
+    formals = {}
+    for mod in app.symbol_table.values():
+        stack = list(mod.functions.values()) + [m for c in mod.types.values() for m in c.callables.values()]
+        for c in stack:
+            for k, n in c.body.items():
+                if n.kind in ("formal_in", "formal_out"):
+                    formals[n.id] = n.of
+    for e in app.param_in:
+        assert e.var and e.var == formals[e.dst], (e.src, e.dst, e.var)
+    for e in app.param_out:
+        assert e.var and e.var == formals[e.src], (e.src, e.dst, e.var)


### PR DESCRIPTION
Closes #195.

The Neo4j catalog declared `var` on `PY_PARAM_IN` / `PY_PARAM_OUT` and the projection wrote no properties at all, so a Cypher predicate on `r.var` went three-valued across every call boundary and silently excluded the path. The SDG assembler always set the variable on those edges (four construction sites in `dataflow/sdg.py`); `emit_l4` dropped it when it built the JSON `ParamEdge`.

Direction taken, per the issue thread: write it, in both projections. `ParamEdge.var` carries the callee-side formal's variable (the parameter name, or `<return>` for the return port), and the projector writes the same value on every `PY_PARAM_IN` / `PY_PARAM_OUT` edge. Present on all of them, never partial. This is the value codeanalyzer-typescript already emits on `param_in[].var`; java declares `var` and writes nothing (its own issue). Additive; `schema_version` unchanged; a 1.5.0 `analysis.json` still parses. Decision recorded in `.claude/SCHEMA_DECISIONS.md`.

Tests: every emitted `PY_PARAM_*` edge carries every declared property (Neo4j); every `param_in` / `param_out` edge's `var` equals the formal vertex's own `var` (JSON). Verified against an emitted graph, not by reading the two files. Passes under pydantic 1 and 2.

Follow-ons to file: python-sdk's `PathHop.var` doc says these hops carry no variable; codeanalyzer-schema's `analysis.schema.json` and the python Neo4j contract copy; the keystone table lists no attrs on `param_in`/`param_out`; codeanalyzer-java declares and never writes.
