### PR TITLE
ci(release): give the release job's tests a base interpreter, as compat already has

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
       # `importorskip` and the decorator-rule regression they exist to catch would
       # ship green. The `compat` job above keeps 3.10 covered.
       - name: Set up Python 3.12
+        id: py312
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -99,6 +100,15 @@ jobs:
         id: test
         continue-on-error: true
         run: uv run pytest
+        env:
+          # Same reason as the `compat` job above, and it has to be repeated per job:
+          # the venv-building CLI tests must find a base interpreter that can create
+          # virtual environments, and inside uv's own venv the discovery walk has no
+          # anchor on the runner. Must be this job's own setup step -- `steps.py310`
+          # belongs to `compat` and would expand to an empty string here. Must be an
+          # absolute path, because the override is checked with `Path(...).exists()`
+          # and never searches PATH.
+          SYSTEM_PYTHON: ${{ steps.py312.outputs.python-path }}
 
       # MUST be `outcome`, not `conclusion`: continue-on-error rewrites `conclusion` to
       # `success`, so a `conclusion == 'failure'` guard never fires and a red test run


### PR DESCRIPTION
`v1.5.1` was tagged, its release run failed, and the tag-deletion gate un-published it. So 1.5.1 is
absent from PyPI and `main` carries the version bump with no tag. That gate working correctly is the
only reason this is a small problem: run
[34361273504](https://github.com/codellm-devkit/codeanalyzer-python/actions/runs/34361273504).

Every failure was in `test/test_cli.py`, all with one cause:

```
RuntimeError('Could not find a suitable base Python interpreter. Current environment:
/home/runner/work/codean... set the SYSTEM_PYTHON environment variable to point to a
working Python interpreter that can create virtual environments.')
```

The venv-building CLI tests run the analyzer, which provisions a virtualenv for the project under
analysis; inside uv's own venv the base-interpreter discovery walk has no anchor on a runner.

**The `compat` job directly above already sets `SYSTEM_PYTHON` and passes. The `release` job never
did.** Same defect as `python-sdk#332`, and found the same way — by a tag deleting itself.

## The change

Two lines of substance. The release job's "Set up Python 3.12" step gains `id: py312`, and its
"Run tests" step gains `env: SYSTEM_PYTHON: ${{ steps.py312.outputs.python-path }}`.

It has to be **this** job's setup step, for two reasons worth stating because the obvious shortcut is
wrong: `steps.py310` belongs to `compat` and would expand to an empty string here, and the two jobs
use different interpreters deliberately — `compat` is 3.10, `release` is 3.12 because the framework
integration tests are gated `python_version >= '3.11'`. The path must also be absolute, since the
override is checked with `Path(...).exists()` and never searches `PATH`; `setup-python`'s
`python-path` output satisfies that.

The comment is repeated in both jobs rather than referenced from one, so the next reader of either
does not have to rediscover why the variable is there.

## Verification

YAML re-parsed after the edit, and the two jobs compared programmatically:

```
release setup id : py312
release test env : {'SYSTEM_PYTHON': '${{ steps.py312.outputs.python-path }}'}
compat  test env : {'SYSTEM_PYTHON': '${{ steps.py310.outputs.python-path }}'}
```

No test changes: the tests were right and the environment was wrong. No version bump — `main` already
carries 1.5.1, so once this merges the release is a re-tag of `v1.5.1` on `main`. PyPI still shows
1.5.0, so nothing was partially published and the re-tag is clean.

Closes #199
